### PR TITLE
학교 인증 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/application.properties
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	// mail service
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 
 	compileOnly(group: 'io.jsonwebtoken', name: 'jjwt', version: '0.7.0')
 	compileOnly('io.jsonwebtoken:jjwt:0.9.0')

--- a/src/main/java/MentosServer/mentos/MentosApplication.java
+++ b/src/main/java/MentosServer/mentos/MentosApplication.java
@@ -2,8 +2,9 @@ package MentosServer.mentos;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class MentosApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -30,6 +30,12 @@ public enum BaseResponseStatus {
     POST_USERS_INVALID_EMAIL(false, 2016, "이메일 형식을 확인해주세요."),
     POST_USERS_EXISTS_EMAIL(false,2017,"중복된 이메일입니다."),
     
+    // [GET] /schoolCertification
+    GET_USERS_EMPTY_EMAIL(false, 2019, "이메일을 입력해주세요."),
+    GET_USERS_INVALID_EMAIL(false, 2020, "이메일 형식을 확인해주세요."),
+    GET_USERS_EXISTS_EMAIL(false,2021,"중복된 이메일입니다."),
+    INVALID_SCHOOL_EMAIL(false, 2022, "학교 이메일이 아닙니다."),
+    
     // Item
     ITEM_EMPTY_ITEM_ID(false, 2018, "아이템 아이디 값을 확인해주세요."),
     

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -65,8 +65,10 @@ public enum BaseResponseStatus {
     MODIFY_FAIL_USERNAME(false,4014,"유저네임 수정 실패"),
 
     PASSWORD_ENCRYPTION_ERROR(false, 4011, "비밀번호 암호화에 실패하였습니다."),
-    PASSWORD_DECRYPTION_ERROR(false, 4012, "비밀번호 복호화에 실패하였습니다.");
+    PASSWORD_DECRYPTION_ERROR(false, 4012, "비밀번호 복호화에 실패하였습니다."),
 
+    // [GET] /schoolCertification
+    MAIL_SEND_ERROR(false, 4015, "메일 전송에 실패하였습니다.");
 
     // 5000 : 필요시 만들어서 쓰세요
     // 6000 : 필요시 만들어서 쓰세요

--- a/src/main/java/MentosServer/mentos/controller/SchoolCertificationController.java
+++ b/src/main/java/MentosServer/mentos/controller/SchoolCertificationController.java
@@ -18,9 +18,9 @@ import static MentosServer.mentos.utils.ValidationRegex.isRegexEmail;
 @RestController
 public class SchoolCertificationController {
 	
-	@Autowired
 	private final SchoolCertificationService schoolCertificationService;
 	
+	@Autowired
 	public SchoolCertificationController(SchoolCertificationService schoolCertificationService){
 		this.schoolCertificationService = schoolCertificationService;
 	}
@@ -40,14 +40,11 @@ public class SchoolCertificationController {
 			return new BaseResponse<>(GET_USERS_EXISTS_EMAIL);
 		}
 		try {
+			// 학교 이메일이 맞는지 검사
 			schoolCertificationService.cmpSchoolEmail(req);
-			// 여기서 email 보내는 service 실행
-			// schoolCertificationService.sendEmail(req.getEmail());
-			
-			
-			GetSchoolCertificationRes res = new GetSchoolCertificationRes();
-			// res.set
-			return new BaseResponse<>(res);
+			// 인증번호 메일 전송
+			String randomNumber = schoolCertificationService.sendEmail(req.getEmail());
+			return new BaseResponse<>(new GetSchoolCertificationRes(randomNumber));
 		} catch (BaseException exception) {
 			return new BaseResponse<>((exception.getStatus()));
 		}

--- a/src/main/java/MentosServer/mentos/controller/SchoolCertificationController.java
+++ b/src/main/java/MentosServer/mentos/controller/SchoolCertificationController.java
@@ -1,0 +1,55 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.GetSchoolCertificationReq;
+import MentosServer.mentos.model.dto.GetSchoolCertificationRes;
+import MentosServer.mentos.service.SchoolCertificationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static MentosServer.mentos.config.BaseResponseStatus.*;
+import static MentosServer.mentos.utils.ValidationRegex.isRegexEmail;
+
+@Slf4j
+@RestController
+public class SchoolCertificationController {
+	
+	@Autowired
+	private final SchoolCertificationService schoolCertificationService;
+	
+	public SchoolCertificationController(SchoolCertificationService schoolCertificationService){
+		this.schoolCertificationService = schoolCertificationService;
+	}
+	
+	@GetMapping("/schoolCertification")
+	public BaseResponse<GetSchoolCertificationRes> schoolCertification(@RequestBody GetSchoolCertificationReq req){
+		// email에 값이 존재하는지, 빈 값으로 요청하지는 않았는지 검사합니다. 빈값으로 요청했다면 에러 메시지를 보냅니다.
+		if (req.getEmail() == null) {
+			return new BaseResponse<>(GET_USERS_EMPTY_EMAIL);
+		}
+		//이메일 정규표현: 입력받은 이메일이 email@domain.xxx와 같은 형식인지 검사합니다. 형식이 올바르지 않다면 에러 메시지를 보냅니다.
+		if (!isRegexEmail(req.getEmail())) {
+			return new BaseResponse<>(GET_USERS_INVALID_EMAIL);
+		}
+		// 중복 확인: 해당 이메일을 가진 유저가 있는지 확인합니다. 중복될 경우, 에러 메시지를 보냅니다.
+		if(!schoolCertificationService.checkEmail(req)) {
+			return new BaseResponse<>(GET_USERS_EXISTS_EMAIL);
+		}
+		try {
+			schoolCertificationService.cmpSchoolEmail(req);
+			// 여기서 email 보내는 service 실행
+			// schoolCertificationService.sendEmail(req.getEmail());
+			
+			
+			GetSchoolCertificationRes res = new GetSchoolCertificationRes();
+			// res.set
+			return new BaseResponse<>(res);
+		} catch (BaseException exception) {
+			return new BaseResponse<>((exception.getStatus()));
+		}
+	}
+}

--- a/src/main/java/MentosServer/mentos/model/domain/TestDomain.java
+++ b/src/main/java/MentosServer/mentos/model/domain/TestDomain.java
@@ -1,4 +1,4 @@
-package MentosServer.mentos.domain;
+package MentosServer.mentos.model.domain;
 
 import lombok.Data;
 

--- a/src/main/java/MentosServer/mentos/model/dto/GetSchoolCertificationReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetSchoolCertificationReq.java
@@ -1,0 +1,10 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.Data;
+
+@Data
+public class GetSchoolCertificationReq {
+	
+	private String school;
+	private String email;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetSchoolCertificationRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetSchoolCertificationRes.java
@@ -1,0 +1,10 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.Data;
+
+@Data
+public class GetSchoolCertificationRes {
+	
+	private int resStatus;
+	private String certificationNumber;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MailDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MailDto.java
@@ -5,7 +5,8 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class GetSchoolCertificationRes {
-	
-	private String certificationNumber;
+public class MailDto {
+	private String address;
+	private String title;
+	private String message;
 }

--- a/src/main/java/MentosServer/mentos/repository/SchoolCertificationRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/SchoolCertificationRepository.java
@@ -1,0 +1,37 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.model.dto.GetSchoolCertificationReq;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class SchoolCertificationRepository {
+	
+	private JdbcTemplate jdbcTemplate;
+	
+	@Autowired //readme 참고
+	public void setDataSource(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+	
+	/**
+	 * 학교 이름으로 학교 email 찾아오기
+	 * @param schoolName
+	 * @return 학교 Email
+	 */
+	public String getSchoolEmail(String schoolName){
+		String getEmailQuery = "select schoolemail from schoolcategory where schoolName = ?";
+		String getEmailParam = schoolName;
+		return this.jdbcTemplate.queryForObject(getEmailQuery, String.class, getEmailParam);
+	}
+	
+	// 이메일 확인
+	public int checkEmail(String email) {
+		String checkEmailQuery = "select exists(select memberemail from member where memberemail = ?)"; // User Table에 해당 email 값을 갖는 유저 정보가 존재하는가?
+		String checkEmailParams = email; // 해당(확인할) 이메일 값
+		return this.jdbcTemplate.queryForObject(checkEmailQuery, int.class, checkEmailParams); // checkEmailQuery, checkEmailParams를 통해 가져온 값(intgud)을 반환한다. -> 쿼리문의 결과(존재하지 않음(False,0),존재함(True, 1))를 int형(0,1)으로 반환됩니다.
+	}
+}

--- a/src/main/java/MentosServer/mentos/service/MailService.java
+++ b/src/main/java/MentosServer/mentos/service/MailService.java
@@ -1,0 +1,24 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.model.dto.MailDto;
+import lombok.AllArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class MailService {
+	
+	private JavaMailSender mailSender;
+	private static final String FROM_ADDRESS = "MENTOS@gmail.com";
+	
+	public void mailSend(MailDto mailDto){
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(mailDto.getAddress());
+		message.setFrom(MailService.FROM_ADDRESS);
+		message.setSubject(mailDto.getTitle());
+		message.setText(mailDto.getMessage());
+		mailSender.send(message);
+	}
+}

--- a/src/main/java/MentosServer/mentos/service/SchoolCertificationService.java
+++ b/src/main/java/MentosServer/mentos/service/SchoolCertificationService.java
@@ -1,0 +1,84 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.dto.GetSchoolCertificationReq;
+import MentosServer.mentos.repository.SchoolCertificationRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+import static MentosServer.mentos.config.BaseResponseStatus.*;
+
+@Slf4j
+@Service
+public class SchoolCertificationService {
+	
+	
+	private SchoolCertificationRepository schoolCertificationRepository;
+	
+	@Autowired
+	public void SchoolCertificationService(SchoolCertificationRepository schoolCertificationRepository){
+		this.schoolCertificationRepository = schoolCertificationRepository;
+	}
+	
+	public boolean checkEmail(GetSchoolCertificationReq req) {
+		if (schoolCertificationRepository.checkEmail(req.getEmail()) == 1) {
+			return false;
+		}
+		else return true;
+	}
+	
+	public void cmpSchoolEmail(GetSchoolCertificationReq req) throws BaseException{
+		try{
+			// 학교 이메일이 맞는지 확인
+			if(!parseEmail(req.getEmail()).equals(schoolCertificationRepository.getSchoolEmail(req.getSchool()))){
+				throw new BaseException(INVALID_SCHOOL_EMAIL); // 학교 이메일 일치하지 않음
+			}
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	
+	public String parseEmail(String email){
+		// email 뒷 부분만 파싱해서 반환
+		String ret = "";
+		boolean flag = false;
+		for(int i=0; i<email.length(); i++){
+			if(email.charAt(i) == '@') {
+				flag = true;
+				continue;
+			}
+			if(flag) {
+				ret += email.charAt(i);
+			}
+		}
+		return ret;
+	}
+	
+	public void sendEmail(String email) throws BaseException{
+		try{
+			String randomNumber = createRandomNumber();
+			// email 보내는 logic 구현하기
+			
+			
+		} catch (Exception exception) {
+		
+		}
+	}
+	
+	public String createRandomNumber(){
+		// random certification number 생성
+		long seed = System.currentTimeMillis(); // 현재 시간을 seed로 (호출 시마다 seed 변경)
+		Random rand = new Random(seed);
+		// 0 ~ 9 사이의 숫자를 4번 랜덤하게 뽑아서 String으로 변환
+		String num = "";
+		for(int i = 0; i < 4; i++) {
+			num += Integer.toString(rand.nextInt(10));
+		}
+		return num;
+	}
+	
+	
+}

--- a/src/main/java/MentosServer/mentos/service/SchoolCertificationService.java
+++ b/src/main/java/MentosServer/mentos/service/SchoolCertificationService.java
@@ -2,6 +2,7 @@ package MentosServer.mentos.service;
 
 import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.model.dto.GetSchoolCertificationReq;
+import MentosServer.mentos.model.dto.MailDto;
 import MentosServer.mentos.repository.SchoolCertificationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,10 +18,12 @@ public class SchoolCertificationService {
 	
 	
 	private SchoolCertificationRepository schoolCertificationRepository;
+	private MailService mailService;
 	
 	@Autowired
-	public void SchoolCertificationService(SchoolCertificationRepository schoolCertificationRepository){
+	public void SchoolCertificationService(SchoolCertificationRepository schoolCertificationRepository, MailService mailService){
 		this.schoolCertificationRepository = schoolCertificationRepository;
+		this.mailService = mailService;
 	}
 	
 	public boolean checkEmail(GetSchoolCertificationReq req) {
@@ -57,14 +60,15 @@ public class SchoolCertificationService {
 		return ret;
 	}
 	
-	public void sendEmail(String email) throws BaseException{
+	public String sendEmail(String email) throws BaseException {
 		try{
 			String randomNumber = createRandomNumber();
-			// email 보내는 logic 구현하기
-			
-			
+			// email 보내기
+			MailDto mailDto = new MailDto(email, "Mentos 인증번호", randomNumber);
+			mailService.mailSend(mailDto);
+			return randomNumber;
 		} catch (Exception exception) {
-		
+			throw new BaseException(MAIL_SEND_ERROR);
 		}
 	}
 	
@@ -79,6 +83,4 @@ public class SchoolCertificationService {
 		}
 		return num;
 	}
-	
-	
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,0 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/mentos
-spring.datasource.username=root
-spring.datasource.password=root
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 학교 인증 API 구현

### 설정 관련 변경사항
- .gitignore 설정 변경 : application.properties를 추가했습니다.
- mail 서비스를 위해 java mail dependency를 추가했습니다.
- SpringSecurity 의존성 때문에 API test가 불가능해서 extend 처리 했습니다.
- model 패키지 아래에 domain과 dto 패키지를 만들었습니다.

### 기능 구현
- 실행 화면과 Flow는 아래 링크에 자세히 적어놓았습니다.
- API 명세서 Notion [링크](https://www.notion.so/API-579ab923462d48ea811da83e1bd494c1)

### 추후 개선 사항
- 현재 제 gmail로 보내고 있어서 보내는 사람에 제 이름이 뜹니다. 추후 Mentos 앱의 gmail을 만들어서 사용해야 할 것 같습니다.
- 테스트용으로 DB에 저희 학교 이메일만 추가해놓았습니다. 추후 UMC의 다른 학교들도 추가할 예정입니다.

