### PR TITLE
로그인 기본 API 구현

### DIFF
--- a/src/main/java/MentosServer/mentos/MentosApplication.java
+++ b/src/main/java/MentosServer/mentos/MentosApplication.java
@@ -2,8 +2,9 @@ package MentosServer.mentos;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class MentosApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/MentosServer/mentos/controller/LoginController.java
+++ b/src/main/java/MentosServer/mentos/controller/LoginController.java
@@ -1,0 +1,47 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.domain.model.PostLoginReq;
+import MentosServer.mentos.domain.model.PostLoginRes;
+import MentosServer.mentos.service.LoginService;
+import MentosServer.mentos.utils.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LoginController {
+
+
+
+    @Autowired
+    private final JwtService jwtService;
+    @Autowired
+    private final LoginService loginService;
+
+
+    public LoginController(LoginService loginService, JwtService jwtService) {
+        this.loginService = loginService;
+        this.jwtService = jwtService;
+    }
+
+
+
+    /**
+     * 로그인 API
+     * [POST] /users/logIn
+     */
+    @ResponseBody
+    @PostMapping("/log-in")
+    public BaseResponse<PostLoginRes> logIn(@RequestBody PostLoginReq postLoginReq) {
+        try {
+            PostLoginRes postLoginRes = loginService.logIn(postLoginReq);
+            return new BaseResponse<>(postLoginRes);
+        } catch (BaseException exception) {
+            return new BaseResponse<>(exception.getStatus());
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/domain/model/Member.java
+++ b/src/main/java/MentosServer/mentos/domain/model/Member.java
@@ -1,0 +1,29 @@
+package MentosServer.mentos.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@AllArgsConstructor
+
+public class Member {
+    private int memberId;
+    private String memberName;
+    private String memberNickName;
+    private int memberStudentId;
+    private String memberEmail;
+    private String memberPw;
+    private int memberSchoolId;
+    private int memberMajorId;
+    private String memberSex;
+    private String memberImage;
+    private int memberMentos;
+    private String memberStatus;
+    private Timestamp memberCreateAt;
+    private Timestamp memberUpdateAt;
+}
+

--- a/src/main/java/MentosServer/mentos/domain/model/PostLoginReq.java
+++ b/src/main/java/MentosServer/mentos/domain/model/PostLoginReq.java
@@ -1,0 +1,14 @@
+package MentosServer.mentos.domain.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+
+public class PostLoginReq {
+    private String memberEmail;
+    private String memberPw;
+}

--- a/src/main/java/MentosServer/mentos/domain/model/PostLoginRes.java
+++ b/src/main/java/MentosServer/mentos/domain/model/PostLoginRes.java
@@ -1,0 +1,14 @@
+package MentosServer.mentos.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+
+public class PostLoginRes {
+    private int memberId;
+    private String jwt;
+}

--- a/src/main/java/MentosServer/mentos/repository/LoginRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/LoginRepository.java
@@ -1,0 +1,54 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.domain.model.Member;
+import MentosServer.mentos.domain.model.PostLoginReq;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class LoginRepository {
+
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    // 로그인
+    public Member getPwd(PostLoginReq postLoginReq) {
+        String getPwdQuery = "select memberId, memberName, memberNickName, memberStudentId, memberEmail, memberPw, memberSchoolId, memberMajorId, memberSex, memberImage, MemberMentos, MemberStatus, memberCreateAt, memberUpdateAt from Member where memberEmail = ?"; // 해당 email을 만족하는 User의 정보들을 조회한다.
+        String getPwdParams = postLoginReq.getMemberEmail(); // 주입될 email값을 클라이언트의 요청에서 주어진 정보를 통해 가져온다.
+
+        return this.jdbcTemplate.queryForObject(getPwdQuery,
+                (rs, rowNum) -> new Member(
+                        rs.getInt("memberId"),
+                        rs.getString("memberName"),
+                        rs.getString("memberNickName"),
+                        rs.getInt("memberStudentId"),
+                        rs.getString("memberEmail"),
+                        rs.getString("memberPw"),
+                        rs.getInt("memberSchoolId"),
+                        rs.getInt("memberMajorId"),
+                        rs.getString("memberSex"),
+                        rs.getString("memberImage"),
+                        rs.getInt("memberMentos"),
+                        rs.getString("memberStatus"),
+                        rs.getTimestamp("memberCreateAt"),
+                        rs.getTimestamp("memberUpdateAt")
+                ),
+                getPwdParams
+        );
+    }
+
+
+
+
+
+
+
+
+}

--- a/src/main/java/MentosServer/mentos/service/LoginService.java
+++ b/src/main/java/MentosServer/mentos/service/LoginService.java
@@ -1,0 +1,52 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.secret.Secret;
+import MentosServer.mentos.domain.model.Member;
+import MentosServer.mentos.domain.model.PostLoginReq;
+import MentosServer.mentos.domain.model.PostLoginRes;
+import MentosServer.mentos.repository.LoginRepository;
+import MentosServer.mentos.utils.AES128;
+import MentosServer.mentos.utils.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static MentosServer.mentos.config.BaseResponseStatus.FAILED_TO_LOGIN;
+import static MentosServer.mentos.config.BaseResponseStatus.PASSWORD_DECRYPTION_ERROR;
+
+@Service
+public class LoginService {
+
+    private final JwtService jwtService;
+    private final LoginRepository loginRepository;
+
+
+
+    @Autowired
+    public LoginService(LoginRepository loginRepository, JwtService jwtService) {
+        this.loginRepository = loginRepository;
+        this.jwtService = jwtService;
+    }
+
+
+    // 로그인(password 검사)
+    public PostLoginRes logIn(PostLoginReq postLoginReq) throws BaseException {
+        Member member = loginRepository.getPwd(postLoginReq);
+        String password;
+        try {
+            password = new AES128(Secret.USER_INFO_PASSWORD_KEY).decrypt(member.getMemberPw()); // 암호화
+        } catch (Exception ignored) {
+            throw new BaseException(PASSWORD_DECRYPTION_ERROR);
+        }
+
+        if (postLoginReq.getMemberPw().equals(password)) { //비말번호가 일치한다면 memberId를 가져온다.
+            int memberId = loginRepository.getPwd(postLoginReq).getMemberId();
+            String jwt = jwtService.createJwt(memberId);
+            return new PostLoginRes(memberId,jwt);
+
+
+        } else { // 비밀번호가 다르다면 에러메세지를 출력한다.
+            throw new BaseException(FAILED_TO_LOGIN);
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/utils/JwtService.java
+++ b/src/main/java/MentosServer/mentos/utils/JwtService.java
@@ -24,11 +24,11 @@ public class JwtService {
     @param userIdx
     @return String
      */
-    public String createJwt(int userIdx){
+    public String createJwt(int memberId){
         Date now = new Date();
         return Jwts.builder()
                 .setHeaderParam("type","jwt")
-                .claim("userIdx",userIdx)
+                .claim("userIdx",memberId)
                 .setIssuedAt(now)
                 .setExpiration(new Date(System.currentTimeMillis()+1*(1000*60*60*24*365)))
                 .signWith(SignatureAlgorithm.HS256, Secret.JWT_SECRET_KEY)
@@ -67,7 +67,7 @@ public class JwtService {
         }
 
         // 3. userIdx 추출
-        return claims.getBody().get("userIdx",Integer.class);  // jwt 에서 userIdx를 추출합니다.
+        return claims.getBody().get("memberId",Integer.class);  // jwt 에서 userIdx를 추출합니다.
     }
 
 }

--- a/src/main/java/MentosServer/mentos/utils/JwtService.java
+++ b/src/main/java/MentosServer/mentos/utils/JwtService.java
@@ -28,7 +28,7 @@ public class JwtService {
         Date now = new Date();
         return Jwts.builder()
                 .setHeaderParam("type","jwt")
-                .claim("userIdx",memberId)
+                .claim("memberId",memberId)
                 .setIssuedAt(now)
                 .setExpiration(new Date(System.currentTimeMillis()+1*(1000*60*60*24*365)))
                 .signWith(SignatureAlgorithm.HS256, Secret.JWT_SECRET_KEY)


### PR DESCRIPTION
### 로그인 API
**설정 변경**
domain에 dto, model 추가
jwtService에 userIdx가 아닌 memberId로 변경


**기능 구현**
로그인 기능 구현
(memberEmail, memberPw 로 받음)

**추후 개선 사항**
회원, 탈퇴회원 구분

기본 회원 정보나 회원가입 틀이 만들어진 다음에 로그인을 덧붙이는 걸 생각했는데 너무 늦춰질것같고 깃에서 머지가 안된 상태에서 함부로 합쳐서 하는건 아닌것같아서 일단 올립니다,, 