### PR TITLE
멘토 글 검색 API 구현

### DIFF
--- a/src/main/java/MentosServer/mentos/controller/MentorSearchController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentorSearchController.java
@@ -1,0 +1,48 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.GetMentorSearchReq;
+import MentosServer.mentos.model.dto.GetMentorSearchRes;
+import MentosServer.mentos.service.MentorSearchService;
+import MentosServer.mentos.utils.JwtService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class MentorSearchController {
+	
+	private final JwtService jwtService;
+	private final MentorSearchService mentorSearchService;
+	
+	@Autowired
+	public MentorSearchController(JwtService jwtService, MentorSearchService mentorSearchService) {
+		this.jwtService = jwtService;
+		this.mentorSearchService = mentorSearchService;
+	}
+	
+	@GetMapping("/mentos/search")
+	public BaseResponse<GetMentorSearchRes> mentorSearch(@RequestBody GetMentorSearchReq req){
+		try {
+			// jwt에서 memberId 뽑아내기
+			String memberId = Integer.toString(jwtService.getMemberId());
+			// 만약 전공 flag가 비어있다면 memberId를 통해 default값 생성
+			if(req.getMajorFlag().size() == 0) {
+				// memberId로 선택했던 전공 가져오기
+				String major = mentorSearchService.getMajorById(memberId);
+				req.getMajorFlag().add(major);
+			}
+			// memberId로 menti의 학교 가져오기
+			String schoolId = mentorSearchService.getSchoolById(memberId);
+			// 검색하기
+			GetMentorSearchRes res = new GetMentorSearchRes(mentorSearchService.mentorSearch(req, schoolId));
+			return new BaseResponse<>(res);
+		} catch (BaseException exception) {
+			return new BaseResponse<>((exception.getStatus()));
+		}
+	}
+}

--- a/src/main/java/MentosServer/mentos/controller/MentorSearchController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentorSearchController.java
@@ -9,6 +9,7 @@ import MentosServer.mentos.utils.JwtService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,8 +26,8 @@ public class MentorSearchController {
 		this.mentorSearchService = mentorSearchService;
 	}
 	
-	@GetMapping("/mentos/search")
-	public BaseResponse<GetMentorSearchRes> mentorSearch(@RequestBody GetMentorSearchReq req){
+	@GetMapping("/mentor/search")
+	public BaseResponse<GetMentorSearchRes> mentorSearch(@ModelAttribute GetMentorSearchReq req){
 		try {
 			// jwt에서 memberId 뽑아내기
 			String memberId = Integer.toString(jwtService.getMemberId());

--- a/src/main/java/MentosServer/mentos/model/domain/Post.java
+++ b/src/main/java/MentosServer/mentos/model/domain/Post.java
@@ -1,0 +1,36 @@
+package MentosServer.mentos.model.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@AllArgsConstructor
+public class Post implements Comparable<Post>{
+	
+	private int postId;
+	
+	private int majorCategoryId;
+	
+	private int memberId;
+	
+	private String postTitle;
+	
+	private String postContents;
+	
+	private Timestamp postCreateAt;
+	
+	private Timestamp postUpdateAt;
+	
+	/**
+	 * 정렬을 위한 method
+	 * @param post
+	 * @return
+	 */
+	@Override
+	public int compareTo(Post post) {
+		if(getPostUpdateAt().toLocalDateTime().isAfter(post.getPostUpdateAt().toLocalDateTime())) return 1;
+		else return 0;
+	}
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetMentorSearchReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMentorSearchReq.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 @Data
 public class GetMentorSearchReq {
 
-	private ArrayList<String> majorFlag;
+	private ArrayList<String> majorFlag = new ArrayList<>();
 	
-	private String searchText;
+	private String searchText = "";
 }

--- a/src/main/java/MentosServer/mentos/model/dto/GetMentorSearchReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMentorSearchReq.java
@@ -1,0 +1,13 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+
+@Data
+public class GetMentorSearchReq {
+
+	private ArrayList<String> majorFlag;
+	
+	private String searchText;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetMentorSearchRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMentorSearchRes.java
@@ -1,0 +1,11 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.ArrayList;
+
+@AllArgsConstructor
+public class GetMentorSearchRes {
+	
+	public ArrayList<PostDto> postArr;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostDto.java
@@ -1,0 +1,17 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PostDto {
+	
+	private String postId;
+	
+	private String memberId;
+	
+	private String postTitle;
+	
+	private String postContents;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostDto.java
@@ -1,10 +1,10 @@
 package MentosServer.mentos.model.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
-@AllArgsConstructor
 public class PostDto {
 	
 	private String postId;
@@ -14,4 +14,13 @@ public class PostDto {
 	private String postTitle;
 	
 	private String postContents;
+	
+	private List<String> imageUrls;
+	
+	public PostDto(String postId, String memberId, String postTitle, String postContents) {
+		this.postId = postId;
+		this.memberId = memberId;
+		this.postTitle = postTitle;
+		this.postContents = postContents;
+	}
 }

--- a/src/main/java/MentosServer/mentos/model/dto/PostDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostDto.java
@@ -9,7 +9,13 @@ public class PostDto {
 	
 	private String postId;
 	
-	private String memberId;
+	private String majorCategoryId;
+	
+	private String mentoId;
+	
+	private String mentoImage;
+	
+	private String mentoNickName;
 	
 	private String postTitle;
 	
@@ -17,9 +23,13 @@ public class PostDto {
 	
 	private List<String> imageUrls;
 	
-	public PostDto(String postId, String memberId, String postTitle, String postContents) {
+	
+	public PostDto(String postId, String majorCategoryId, String mentoId, String mentoImage, String mentoNickName, String postTitle, String postContents) {
 		this.postId = postId;
-		this.memberId = memberId;
+		this.majorCategoryId = majorCategoryId;
+		this.mentoId = mentoId;
+		this.mentoImage = mentoImage;
+		this.mentoNickName = mentoNickName;
 		this.postTitle = postTitle;
 		this.postContents = postContents;
 	}

--- a/src/main/java/MentosServer/mentos/model/dto/PostWithProfile.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostWithProfile.java
@@ -1,4 +1,4 @@
-package MentosServer.mentos.model.domain;
+package MentosServer.mentos.model.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -7,13 +7,17 @@ import java.sql.Timestamp;
 
 @Data
 @AllArgsConstructor
-public class Post implements Comparable<Post>{
+public class PostWithProfile implements Comparable<PostWithProfile>{
 	
 	private int postId;
 	
 	private int majorCategoryId;
 	
 	private int memberId;
+	
+	private String memberNickName;
+	
+	private String mentoImage;
 	
 	private String postTitle;
 	
@@ -29,7 +33,7 @@ public class Post implements Comparable<Post>{
 	 * @return
 	 */
 	@Override
-	public int compareTo(Post post) {
+	public int compareTo(PostWithProfile post) {
 		if(getPostUpdateAt().toLocalDateTime().isAfter(post.getPostUpdateAt().toLocalDateTime())) return 1;
 		else return 0;
 	}

--- a/src/main/java/MentosServer/mentos/repository/MentorSearchRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentorSearchRepository.java
@@ -74,4 +74,14 @@ public class MentorSearchRepository {
 	public String changeParam(String text){
 		return "%" + text + "%";
 	}
+	
+	public List<String> getImageUrl(String postId){
+		String searchImageQuery = "select imageUrl from Image where postId = ?";
+		String searchImageParam = postId;
+		return this.jdbcTemplate.query(searchImageQuery,
+				(rs, rowNum) -> rs.getString("imageUrl")
+				, searchImageParam
+		);
+	}
+	
 }

--- a/src/main/java/MentosServer/mentos/repository/MentorSearchRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentorSearchRepository.java
@@ -1,0 +1,77 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.model.domain.Post;
+import MentosServer.mentos.model.dto.GetMentorSearchReq;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+@Slf4j
+@Repository
+public class MentorSearchRepository {
+	
+	private JdbcTemplate jdbcTemplate;
+	
+	@Autowired //readme 참고
+	public void setDataSource(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+	
+	public String getMajorById(String memberId){
+		// Menti table에 접근해서 가져와야함
+		String getMajorQuery = "select mentiMajorFirst from menti where memberId = ?";
+		String getMajorParam = memberId;
+		return this.jdbcTemplate.queryForObject(getMajorQuery, String.class, getMajorParam);
+	}
+	
+	public String getSchoolById(String memberId){
+		// Menti table에 접근해서 가져와야함
+		String getMajorQuery = "select memberSchoolId from member where memberId = ?";
+		String getMajorParam = memberId;
+		return Integer.toString(this.jdbcTemplate.queryForObject(getMajorQuery, Integer.class, getMajorParam));
+	}
+	
+	/**
+	 * Post 테이블과 Member 테이블을 Join
+	 * majorCategoryId가 일치하는 Tuple만 뽑아오기
+	 * 그 중 멤버 닉네임, 글 제목, 글 내용 중에 일치하는 Tuple들만 반환
+	 * 이때 현재 상태가 ACTIVE가 아니라면 제외(탈퇴 회원)
+	 * 또한 같은 학교여야만 함 (현재 DB는 모든 학교의 멘토 같이 관리)
+	 * @param req
+	 * @return
+	 */
+	public List<Post> getPosts(GetMentorSearchReq req, String schoolId){
+		String arrayToString = String.join(",", req.getMajorFlag());
+		String searchQuery =
+				"select postId, majorCategoryId, memberId, postTitle, postContents, postCreateAt, postUpdateAt " +
+				"from " +
+					"(" +
+					"select * " +
+					"from member NATURAL JOIN post " +
+					"where majorCategoryId IN (" + arrayToString + ")" + " AND memberStatus = 'ACTIVE' AND memberSchoolId = " + schoolId +
+					") T " +
+				"where memberNickName LIKE ? OR postTitle LIKE ? OR postContents LIKE ?";
+		String param = changeParam(req.getSearchText());
+		Object[] searchParam = new Object[]{param, param, param};
+		return this.jdbcTemplate.query(searchQuery,
+				(rs, rowNum) -> new Post(
+						rs.getInt("postId"),
+						rs.getInt("majorCategoryId"),
+						rs.getInt("memberId"),
+						rs.getString("postTitle"),
+						rs.getString("postContents"),
+						rs.getTimestamp("postCreateAt"),
+						rs.getTimestamp("postUpdateAt")
+				),
+				searchParam
+		);
+	}
+	
+	public String changeParam(String text){
+		return "%" + text + "%";
+	}
+}

--- a/src/main/java/MentosServer/mentos/service/MentorSearchService.java
+++ b/src/main/java/MentosServer/mentos/service/MentorSearchService.java
@@ -1,0 +1,70 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.domain.Post;
+import MentosServer.mentos.model.dto.GetMentorSearchReq;
+import MentosServer.mentos.model.dto.PostDto;
+import MentosServer.mentos.repository.MentorSearchRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+
+@Service
+public class MentorSearchService {
+
+	private final MentorSearchRepository mentorSearchRepository;
+	
+	@Autowired
+	public MentorSearchService(MentorSearchRepository mentorSearchRepository) {
+		this.mentorSearchRepository = mentorSearchRepository;
+	}
+	
+	// memberId로 선택했던 전공 찾기
+	public String getMajorById(String memberId) throws BaseException{
+		try{
+			return mentorSearchRepository.getMajorById(memberId);
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	
+	// memberId로 menti 학교 찾기
+	public String getSchoolById(String memberId) throws BaseException{
+		try{
+			return mentorSearchRepository.getSchoolById(memberId);
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	
+	// 검색 결과 반환
+	public ArrayList<PostDto> mentorSearch(GetMentorSearchReq req, String schoolId) throws BaseException{
+		try{
+			List<Post> posts = mentorSearchRepository.getPosts(req, schoolId);
+			// UpdateAt으로 정렬 실행
+			ArrayList<PostDto> postDtos = sortByUpdateAt(posts);
+			return postDtos;
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	
+	/**
+	 * updateAt 기준으로 정렬 수행
+	 * @param arr
+	 * @return
+	 */
+	public ArrayList<PostDto> sortByUpdateAt(List<Post> arr) {
+		ArrayList<PostDto> ret = new ArrayList<PostDto>();
+		Collections.sort(arr);
+		for(Post p : arr){
+			ret.add(new PostDto(Integer.toString(p.getPostId()), Integer.toString(p.getMemberId()), p.getPostTitle(), p.getPostContents()));
+		}
+		return ret;
+	}
+}

--- a/src/main/java/MentosServer/mentos/service/MentorSearchService.java
+++ b/src/main/java/MentosServer/mentos/service/MentorSearchService.java
@@ -1,7 +1,7 @@
 package MentosServer.mentos.service;
 
 import MentosServer.mentos.config.BaseException;
-import MentosServer.mentos.model.domain.Post;
+import MentosServer.mentos.model.dto.PostWithProfile;
 import MentosServer.mentos.model.dto.GetMentorSearchReq;
 import MentosServer.mentos.model.dto.PostDto;
 import MentosServer.mentos.repository.MentorSearchRepository;
@@ -45,7 +45,7 @@ public class MentorSearchService {
 	// 검색 결과 반환
 	public ArrayList<PostDto> mentorSearch(GetMentorSearchReq req, String schoolId) throws BaseException{
 		try{
-			List<Post> posts = mentorSearchRepository.getPosts(req, schoolId);
+			List<PostWithProfile> posts = mentorSearchRepository.getPosts(req, schoolId);
 			// UpdateAt으로 정렬 실행
 			ArrayList<PostDto> postDtos = sortByUpdateAt(posts);
 			// postId를 가지고 관련 이미지들 찾아서 추가
@@ -72,11 +72,12 @@ public class MentorSearchService {
 	 * @param arr
 	 * @return
 	 */
-	public ArrayList<PostDto> sortByUpdateAt(List<Post> arr) {
+	public ArrayList<PostDto> sortByUpdateAt(List<PostWithProfile> arr) {
 		ArrayList<PostDto> ret = new ArrayList<PostDto>();
 		Collections.sort(arr);
-		for(Post p : arr){
-			ret.add(new PostDto(Integer.toString(p.getPostId()), Integer.toString(p.getMemberId()), p.getPostTitle(), p.getPostContents()));
+		for(PostWithProfile p : arr){
+			ret.add(new PostDto(Integer.toString(p.getPostId()), Integer.toString(p.getMajorCategoryId()), Integer.toString(p.getMemberId()),
+					p.getMentoImage(), p.getMemberNickName(), p.getPostTitle(), p.getPostContents()));
 		}
 		return ret;
 	}

--- a/src/main/java/MentosServer/mentos/service/MentorSearchService.java
+++ b/src/main/java/MentosServer/mentos/service/MentorSearchService.java
@@ -48,9 +48,22 @@ public class MentorSearchService {
 			List<Post> posts = mentorSearchRepository.getPosts(req, schoolId);
 			// UpdateAt으로 정렬 실행
 			ArrayList<PostDto> postDtos = sortByUpdateAt(posts);
+			// postId를 가지고 관련 이미지들 찾아서 추가
+			getImageUrlByPostId(postDtos);
 			return postDtos;
 		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
 			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	
+	/**
+	 * postId로 해당 포스트의 Image들 찾아서 추가
+	 * @param postDtos
+	 */
+	private void getImageUrlByPostId(ArrayList<PostDto> postDtos) {
+		for(PostDto post : postDtos) {
+			String postId = post.getPostId();
+			post.setImageUrls(mentorSearchRepository.getImageUrl(postId));
 		}
 	}
 	


### PR DESCRIPTION
## 멘토 글 검색 API 구현

### ✔ 기능 구현

![image](https://user-images.githubusercontent.com/65909160/150689747-46d5a7f7-2078-473e-b100-076bdd10a048.png)

**1) 선택된 전공 리스트(majorFlag)와 검색어(searchText)를 사용하여 API 호출**
- **이때 전공 리스트, 검색어가 비어있어도 됨**
    - **해당 경우에는 요청하는 멘티가 선택했던 전공으로 default값 생성**

**2) 멘티의 학교 아이디 가져오기**
- **같은 학교의 멘토만 찾아서 반환해야 하기 때문에 필요**

**3) 검색어를 사용하여 검색**
- **선택된 전공만**
- **같은 학교 멘토가 작성한 글만**
- **현재 멘토가 활동중인 상태 (탈퇴 안한 = ACTIVE)**
- **검색어는 멘토의 닉네임, 작성한 글의 제목, 작성한 글의 내용에서 찾는다**

**4) 글 관련 사진 결과에 추가**
- **검색된 postId를 통해 관련 Image 검색 후 결과에 추가**

**5) 검색된 결과 list로 반환**
- **검색된 결과가 없으면 비어있는 리스트 반환**

### ✔ 추후 개선 사항
현재 로그인 서비스와 연계해서 테스트 해볼수가 없어서 jwtService를 사용하여 memberId를 뽑아내는 부분은 테스트하지 못했습니다. (memberId를 정상적으로 뽑아냈다 가정하고 테스트하였습니다.)
전체 API 연계 테스트를 조만간 진행해야 할 것 같네요! 

### ✔ 기타
해당 API와 관련된 설명은 API 명세서에 자세히 적어놓았습니다.
