### PR TITLE
멘토가 멘티 검색하는 기능 구현

### DIFF
--- a/src/main/java/MentosServer/mentos/controller/MenteeSearchController.java
+++ b/src/main/java/MentosServer/mentos/controller/MenteeSearchController.java
@@ -1,0 +1,49 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.GetMenteeSearchReq;
+import MentosServer.mentos.model.dto.GetMenteeSearchRes;
+import MentosServer.mentos.service.MenteeSearchService;
+import MentosServer.mentos.utils.JwtService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class MenteeSearchController {
+	
+	private final JwtService jwtService;
+	private final MenteeSearchService menteeSearchService;
+	
+	@Autowired
+	public MenteeSearchController(JwtService jwtService, MenteeSearchService menteeSearchService) {
+		this.jwtService = jwtService;
+		this.menteeSearchService = menteeSearchService;
+	}
+	
+	@GetMapping("/mentee/search")
+	public BaseResponse<GetMenteeSearchRes> menteeSearch(@ModelAttribute GetMenteeSearchReq req){
+		try {
+			// jwt에서 memberId 뽑아내기
+			String memberId = Integer.toString(jwtService.getMemberId());
+			// 만약 전공 flag가 비어있다면 memberId를 통해 default값 생성
+			if(req.getMajorFlag().size() == 0) {
+				// memberId로 선택했던 전공 가져오기
+				String major = menteeSearchService.getMajorById(memberId);
+				req.getMajorFlag().add(major);
+			}
+			// memberId로 mento의 학교 가져오기
+			String schoolId = menteeSearchService.getSchoolById(memberId);
+			// 검색하기
+			GetMenteeSearchRes res = new GetMenteeSearchRes(menteeSearchService.menteeSearch(req, schoolId));
+			return new BaseResponse<>(res);
+		} catch (BaseException exception) {
+			return new BaseResponse<>((exception.getStatus()));
+		}
+	}
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetMenteeSearchReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMenteeSearchReq.java
@@ -1,0 +1,14 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+
+@Data
+public class GetMenteeSearchReq {
+	
+	private ArrayList<String> majorFlag = new ArrayList<>();
+	
+	private String searchText = "";
+	
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetMenteeSearchRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMenteeSearchRes.java
@@ -1,0 +1,13 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.ArrayList;
+
+@AllArgsConstructor
+@Data
+public class GetMenteeSearchRes {
+
+	private ArrayList<MenteeSearchDto> mentiArr;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MenteeSearchDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MenteeSearchDto.java
@@ -1,0 +1,21 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MenteeSearchDto {
+	
+	private String mentiId;
+	
+	private String mentiNickName;
+	
+	private String mentiMajorFirst;
+	
+	private String mentiMajorSecond;
+	
+	private String mentiImage;
+	
+	private String mentiIntro;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MenteeWithNickName.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MenteeWithNickName.java
@@ -1,0 +1,38 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@AllArgsConstructor
+public class MenteeWithNickName implements Comparable<MenteeWithNickName>{
+	
+	private int memberId;
+	
+	private int mentiMajorFirst;
+	
+	private int mentiMajorSecond;
+	
+	private String memberNickName;
+	
+	private String mentiImage;
+	
+	private String mentiIntro;
+	
+	private Timestamp mentiCreateAt;
+	
+	private Timestamp mentiUpdateAt;
+	
+	/**
+	 * 정렬을 위한 method
+	 * @param mentee
+	 * @return
+	 */
+	@Override
+	public int compareTo(MenteeWithNickName mentee) {
+		if(getMentiUpdateAt().toLocalDateTime().isAfter(mentee.getMentiUpdateAt().toLocalDateTime())) return 1;
+		else return 0;
+	}
+}

--- a/src/main/java/MentosServer/mentos/repository/MenteeSearchRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MenteeSearchRepository.java
@@ -1,0 +1,73 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.model.dto.MenteeWithNickName;
+import MentosServer.mentos.model.dto.GetMenteeSearchReq;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+@Slf4j
+@Repository
+public class MenteeSearchRepository {
+	
+	private JdbcTemplate jdbcTemplate;
+	
+	@Autowired //readme 참고
+	public void setDataSource(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+	
+	public String getMajorById(String memberId){
+		// Mento table에 접근해서 가져와야함
+		String getMajorQuery = "select mentoMajorFirst from mento where memberId = ?";
+		String getMajorParam = memberId;
+		return this.jdbcTemplate.queryForObject(getMajorQuery, String.class, getMajorParam);
+	}
+	
+	public String getSchoolById(String memberId){
+		String getSchoolQuery = "select memberSchoolId from member where memberId = ?";
+		String getSchoolParam = memberId;
+		return Integer.toString(this.jdbcTemplate.queryForObject(getSchoolQuery, Integer.class, getSchoolParam));
+	}
+	
+	public List<MenteeWithNickName> getMentee(GetMenteeSearchReq req, String schoolId){
+		String arrayToString = String.join(",", req.getMajorFlag());
+		String searchQuery =
+				"SELECT memberId, mentiMajorFirst, mentiMajorSecond, memberNickName, mentiImage, mentiIntro, mentiCreateAt, mentiUpdateAt" +
+						" FROM menti NATURAL JOIN member" +
+						" WHERE (mentiMajorFirst IN (" + arrayToString + ") OR mentiMajorSecond IN (" + arrayToString + ")) AND memberStatus = 'ACTIVE' AND memberSchoolId = "+schoolId +
+						" AND (memberName LIKE ? OR memberNickName LIKE ? OR mentiIntro LIKE ?)";
+		String param = changeParam(req.getSearchText());
+		Object[] searchParam = new Object[]{param, param, param};
+		return this.jdbcTemplate.query(searchQuery,
+				(rs, rowNum) -> new MenteeWithNickName(
+						rs.getInt("memberId"),
+						rs.getInt("mentiMajorFirst"),
+						rs.getInt("mentiMajorSecond"),
+						rs.getString("memberNickName"),
+						rs.getString("mentiImage"),
+						rs.getString("mentiIntro"),
+						rs.getTimestamp("mentiCreateAt"),
+						rs.getTimestamp("mentiUpdateAt")
+				),
+				searchParam
+		);
+	}
+	
+	public String changeParam(String text){
+		return "%" + text + "%";
+	}
+	
+	public List<String> getImageUrl(String postId){
+		String searchImageQuery = "select imageUrl from Image where postId = ?";
+		String searchImageParam = postId;
+		return this.jdbcTemplate.query(searchImageQuery,
+				(rs, rowNum) -> rs.getString("imageUrl")
+				, searchImageParam
+		);
+	}
+}

--- a/src/main/java/MentosServer/mentos/service/MenteeSearchService.java
+++ b/src/main/java/MentosServer/mentos/service/MenteeSearchService.java
@@ -1,0 +1,70 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.dto.MenteeWithNickName;
+import MentosServer.mentos.model.dto.GetMenteeSearchReq;
+import MentosServer.mentos.model.dto.MenteeSearchDto;
+import MentosServer.mentos.repository.MenteeSearchRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+
+@Service
+public class MenteeSearchService {
+	
+	private final MenteeSearchRepository menteeSearchRepository;
+	
+	@Autowired
+	public MenteeSearchService(MenteeSearchRepository menteeSearchRepository) {
+		this.menteeSearchRepository = menteeSearchRepository;
+	}
+	
+	// memberId로 선택했던 전공 찾기
+	public String getMajorById(String memberId) throws BaseException {
+		try{
+			return menteeSearchRepository.getMajorById(memberId);
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	
+	// memberId로 mentor 학교 찾기
+	public String getSchoolById(String memberId) throws BaseException{
+		try{
+			return menteeSearchRepository.getSchoolById(memberId);
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	
+	// 검색 결과 반환
+	public ArrayList<MenteeSearchDto> menteeSearch(GetMenteeSearchReq req, String schoolId) throws BaseException{
+		try{
+			List<MenteeWithNickName> mentees = menteeSearchRepository.getMentee(req, schoolId);
+			// UpdateAt으로 정렬 실행
+			ArrayList<MenteeSearchDto> menteeDto = sortByUpdateAt(mentees);
+			return menteeDto;
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	/**
+	 * updateAt 기준으로 정렬 수행
+	 * @param arr
+	 * @return
+	 */
+	public ArrayList<MenteeSearchDto> sortByUpdateAt(List<MenteeWithNickName> arr) {
+		ArrayList<MenteeSearchDto> ret = new ArrayList<MenteeSearchDto>();
+		Collections.sort(arr);
+		for(MenteeWithNickName m : arr){
+			ret.add(new MenteeSearchDto(Integer.toString(m.getMemberId()), m.getMemberNickName(), Integer.toString(m.getMentiMajorFirst()), Integer.toString(m.getMentiMajorSecond()),
+					m.getMentiImage(), m.getMentiIntro()));
+		}
+		return ret;
+	}
+}


### PR DESCRIPTION
## 멘토가 멘티 검색하는 기능 구현

![image](https://user-images.githubusercontent.com/65909160/150689162-21d94476-f75a-4c02-a8be-200a57414129.png)

### ✔ Description

**1) 선택된 전공 리스트(majorFlag)와 검색어(searchText)를 사용하여 API 호출**

- **이때 전공 리스트, 검색어가 비어있어도 됨**
    - **해당 경우에는 요청하는 멘토가 선택했던 전공으로 default값 생성**

**2) 멘토의 학교 아이디 가져오기**

- **같은 학교의 멘티만 찾아서 반환해야 하기 때문에 필요**

**3) 검색어를 사용하여 검색**

- **선택된 전공만**
- **같은 학교 멘티만**
- **현재 멘티가 활동중인 상태 (탈퇴 안한 = ACTIVE)**
- **검색어는 멘토의 이름, 닉네임과 소개 글에서**

**4) 검색된 결과 list로 반환**

- **검색된 결과가 없으면 비어있는 리스트 반환**

### ✔ 기타

- **API 명세서에 자세한 설명은 적어놓겠습니다.**
