### PR TITLE
멘토링 요청/ 요청 수락 관련 APIs

### DIFF
--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -43,13 +43,22 @@ public enum BaseResponseStatus {
      * ROZY
      * 201 - 300 : Requset 오류
      */
-    //[POST] /setProfile
+    //[POST] members/setProfile
     POST_PROFILE_INVALID_ROLE(false, 2201, "올바르지 않은 역할(멘토/멘티) 선택입니다."),
     POST_PROFILE_EMPTY_MEMBERID(false, 2202, "memberId가 입력되지 않았습니다."),
     POST_PROFILE_EMPTY_MAJORFIRST(false, 2203, "majorFirst가 선택되지 않았습니다."),
     POST_PROFILE_EMPTY_INTRODUCTION(false, 2204, "자기소개가 입력되지 않았습니다."),
     POST_PROFILE_SHORT_INTRODUCTION(false, 2205, "자기소개는 10글자 이상 입력해주세요."),
     POST_PROFILE_INVALID_IMAGEURL(false, 2206, "이미지 확장자(jpg | jpeg | png | bmp)를 확인해주세요."),
+
+    //[POST] /mentoring/registration
+    POST_MENTORING_INVALID_MENTOID(false, 2208, "유효하지 않은 mentoId 값입니다."),
+    POST_MENTORING_GERATER_MENTORINGCOUNT(false, 2209, "멘토링 횟수(mentoringCount)는 최대 10입니다."),
+    POST_MENTORING_LESS_MENTORINGCOUNT(false, 2210, "멘토링 횟수(mentoringCount)는 최소 1입니다."),
+    POST_MENTORING_INVALID_MAJORCATEGORYID(false, 2211, "유효하지 않은 멘토-쓰 종류(majorCategoryId)값 입니다."),
+    POST_MENTORING_INVALID_MENTOS(false, 2212, "멘토-쓰 개수(mentos)의 형식을 확인해주세요."),
+    POST_MENTORING_SAME_MENTOMENTI(false, 2213, "멘토(mentoId)와 멘티(mentiId)가 같습니다."),
+
 
     // [POST] /sign-up
     EMPTY_USER_NAME(false,2401,"이름을 입력해주세요"),
@@ -77,6 +86,15 @@ public enum BaseResponseStatus {
     VALID_USER_NICKNAME(true,3402,"사용가능한 닉네임입니다."),
 
 
+    /**
+     * ROZY
+     * 301 -  400 : Response 오류
+     */
+    //[POST] members/setProfile
+    POST_DUPLICATED_PROFILE(false,3302,"멘티, 멘토 프로필이 모두 존재합니다."),
+
+    //[POST] /mentoring/registration
+    POST_MENTORING_DUPLICATED_MENTORING(false,3303, "수락 요청 대기중인 멘토링 요청이 있습니다."),
 
     /**
      * 4000 : Database, Server 오류
@@ -90,12 +108,8 @@ public enum BaseResponseStatus {
     PASSWORD_ENCRYPTION_ERROR(false, 4011, "비밀번호 암호화에 실패하였습니다."),
     PASSWORD_DECRYPTION_ERROR(false, 4012, "비밀번호 복호화에 실패하였습니다."),
 
-    /**
-     * ROZY
-     * 301 -  400 : Response 오류
-     */
+    //[POST] members/setProfile
     FAILED_TO_SETPROFILE(false,4301,"프로필 등록에 실패했습니다."),
-    POST_DUPLICATED_PROFILE(false,4302,"멘티, 멘토 프로필이 모두 존재합니다."),
 
 
     // [GET] /schoolCertification

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -97,10 +97,10 @@ public enum BaseResponseStatus {
      * 301 -  400 : Response 오류
      */
     //[POST] /members/setProfile
-    POST_DUPLICATED_PROFILE(false,3302,"멘티, 멘토 프로필이 모두 존재합니다."),
+    POST_DUPLICATED_PROFILE(false,3301,"멘티, 멘토 프로필이 모두 존재합니다."),
 
     //[POST] /mentoring/registration
-    POST_MENTORING_DUPLICATED_MENTORING(false,3303, "수락 요청 대기중인 멘토링 요청이 있습니다."),
+    POST_MENTORING_DUPLICATED_MENTORING(false,3302, "해당 멘토에게 수락 요청 대기 중인 멘토링 요청이 있습니다."),
 
     /**
      * 4000 : Database, Server 오류

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -59,6 +59,9 @@ public enum BaseResponseStatus {
     POST_MENTORING_INVALID_MENTOS(false, 2212, "멘토-쓰 개수(mentos)의 형식을 확인해주세요."),
     POST_MENTORING_SAME_MENTOMENTI(false, 2213, "멘토(mentoId)와 멘티(mentiId)가 같습니다."),
 
+    //[POST] /mentoring/acceptance
+    POST_INVALID_MENTORING(false,2214, "유효하지 않은 멘토링 요청입니다."),
+
 
     // [POST] /sign-up
     EMPTY_USER_NAME(false,2401,"이름을 입력해주세요"),
@@ -90,7 +93,7 @@ public enum BaseResponseStatus {
      * ROZY
      * 301 -  400 : Response 오류
      */
-    //[POST] members/setProfile
+    //[POST] /members/setProfile
     POST_DUPLICATED_PROFILE(false,3302,"멘티, 멘토 프로필이 모두 존재합니다."),
 
     //[POST] /mentoring/registration
@@ -110,6 +113,10 @@ public enum BaseResponseStatus {
 
     //[POST] members/setProfile
     FAILED_TO_SETPROFILE(false,4301,"프로필 등록에 실패했습니다."),
+
+    //[POST] /mentoring/acceptance
+    FAILED_TO_ACCEPTMENTORING(false,4302,"멘토링 요청 수락에 실패했습니다."),
+    FAILED_TO_REJECTMENTORING(false,4303,"멘토링 요청 거절에 실패했습니다."),
 
 
     // [GET] /schoolCertification

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -97,10 +97,10 @@ public enum BaseResponseStatus {
      * 301 -  400 : Response 오류
      */
     //[POST] /members/setProfile
-    POST_DUPLICATED_PROFILE(false,3301,"멘티, 멘토 프로필이 모두 존재합니다."),
+    POST_DUPLICATED_PROFILE(false,3201,"멘티, 멘토 프로필이 모두 존재합니다."),
 
     //[POST] /mentoring/registration
-    POST_MENTORING_DUPLICATED_MENTORING(false,3302, "해당 멘토에게 수락 요청 대기 중인 멘토링 요청이 있습니다."),
+    POST_MENTORING_DUPLICATED_MENTORING(false,3202, "해당 멘토에게 수락 요청 대기 중인 멘토링 요청이 있습니다."),
 
     /**
      * 4000 : Database, Server 오류
@@ -115,15 +115,17 @@ public enum BaseResponseStatus {
     PASSWORD_DECRYPTION_ERROR(false, 4012, "비밀번호 복호화에 실패하였습니다."),
 
     //[POST] members/setProfile
-    FAILED_TO_SETPROFILE(false,4301,"프로필 등록에 실패하였습니다."),
+    FAILED_TO_SETPROFILE(false,4201,"프로필 등록에 실패하였습니다."),
 
     //[POST] /mentoring/acceptance
-    FAILED_TO_ACCEPTMENTORING(false,4302,"멘토링 요청 수락에 실패하였습니다."),
-    FAILED_TO_REJECTMENTORING(false,4303,"멘토링 요청 거절에 실패하였습니다."),
+    FAILED_TO_ACCEPTMENTORING(false,4202,"멘토링 요청 수락에 실패하였습니다."),
+    FAILED_TO_REJECTMENTORING(false,4203,"멘토링 요청 거절에 실패하였습니다."),
 
     //[PATCH] /mentoring/stop
-    FAILED_TO_STOPMENTORING(false,4304,"멘토링 강제 종료에 실패하였습니다."),
+    FAILED_TO_STOPMENTORING(false,4204,"멘토링 강제 종료에 실패하였습니다."),
 
+    //[DELETE] /mentoring/cancel
+    FAILDE_TO_DELETEMENTORING(false,4203,"멘토링 요청 취소에 실패하였습니다."),
 
     // [GET] /schoolCertification
     MAIL_SEND_ERROR(false, 4015, "메일 전송에 실패하였습니다.");

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -62,6 +62,9 @@ public enum BaseResponseStatus {
     //[POST] /mentoring/acceptance
     POST_INVALID_MENTORING(false,2214, "유효하지 않은 멘토링 요청입니다."),
 
+    //[PATCH] /mentoring/stop
+    PATCH_INVALID_MENTORING(false,2215, "유효하지 않은 멘토링입니다."),
+
 
     // [POST] /sign-up
     EMPTY_USER_NAME(false,2401,"이름을 입력해주세요"),
@@ -112,11 +115,14 @@ public enum BaseResponseStatus {
     PASSWORD_DECRYPTION_ERROR(false, 4012, "비밀번호 복호화에 실패하였습니다."),
 
     //[POST] members/setProfile
-    FAILED_TO_SETPROFILE(false,4301,"프로필 등록에 실패했습니다."),
+    FAILED_TO_SETPROFILE(false,4301,"프로필 등록에 실패하였습니다."),
 
     //[POST] /mentoring/acceptance
-    FAILED_TO_ACCEPTMENTORING(false,4302,"멘토링 요청 수락에 실패했습니다."),
-    FAILED_TO_REJECTMENTORING(false,4303,"멘토링 요청 거절에 실패했습니다."),
+    FAILED_TO_ACCEPTMENTORING(false,4302,"멘토링 요청 수락에 실패하였습니다."),
+    FAILED_TO_REJECTMENTORING(false,4303,"멘토링 요청 거절에 실패하였습니다."),
+
+    //[PATCH] /mentoring/stop
+    FAILED_TO_STOPMENTORING(false,4304,"멘토링 강제 종료에 실패하였습니다."),
 
 
     // [GET] /schoolCertification

--- a/src/main/java/MentosServer/mentos/controller/MentoringController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentoringController.java
@@ -65,7 +65,7 @@ public class MentoringController {
      * @return PostAcceptMentoringRes
      */
     @ResponseBody
-    @PostMapping("/acceptance")
+    @PatchMapping("/acceptance")
     public BaseResponse<PostAcceptMentoringRes> acceptMentoring(@RequestParam("mentoringId") int mentoringId, @RequestParam("accept") Boolean acceptance){
         try{
             int mentoIdByJwt = jwtService.getMemberId();

--- a/src/main/java/MentosServer/mentos/controller/MentoringController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentoringController.java
@@ -3,6 +3,7 @@ package MentosServer.mentos.controller;
 import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.config.BaseResponse;
 import MentosServer.mentos.config.BaseResponseStatus;
+import MentosServer.mentos.model.dto.PostAcceptMentoringRes;
 import MentosServer.mentos.model.dto.PostMentoringReq;
 import MentosServer.mentos.model.dto.PostMentoringRes;
 import MentosServer.mentos.service.MentoringService;
@@ -34,7 +35,6 @@ public class MentoringController {
      * 멘토링 등록 API
      * @param postMentoringReq
      * @return PostMentoringRes => 멘토링 등록 ID, 멘토 ID, 멘티 ID
-     *
      */
     @ResponseBody
     @PostMapping("/registration")
@@ -55,6 +55,24 @@ public class MentoringController {
 
             PostMentoringRes postMentoringRes = mentoringService.createMentoring(postMentoringReq);
             return new BaseResponse<>(postMentoringRes);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 멘토링 요청 수락/거절 API
+     * @param mentoringId
+     * @return PostAcceptMentoringRes
+     */
+    @ResponseBody
+    @PostMapping("/acceptance")
+    public BaseResponse<PostAcceptMentoringRes> acceptMentoring(@RequestParam("mentoringId") int mentoringId, @RequestParam("accept") Boolean acceptance){
+        try{
+            int mentoIdByJwt = jwtService.getMemberId();
+            PostAcceptMentoringRes postAcceptMentoringRes = mentoringService.acceptMentoring(mentoringId, mentoIdByJwt, acceptance);
+
+            return new BaseResponse<>(postAcceptMentoringRes);
         } catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/MentosServer/mentos/controller/MentoringController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentoringController.java
@@ -94,4 +94,21 @@ public class MentoringController {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+    /**
+     * 멘토링 요청 취소 API
+     * @param mentoringId
+     * @return String
+     */
+    @ResponseBody
+    @DeleteMapping("/cancel")
+    public BaseResponse<String> deleteMentoring(@RequestParam("mentoringId") int mentoringId){
+        try{
+            int mentiByJwt = jwtService.getMemberId();
+            mentoringService.deleteMentoring(mentoringId, mentiByJwt);
+            return new BaseResponse<>("멘토링 요청이 취소되었습니다.");
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/src/main/java/MentosServer/mentos/controller/MentoringController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentoringController.java
@@ -1,0 +1,61 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.config.BaseResponseStatus;
+import MentosServer.mentos.model.dto.PostMentoringReq;
+import MentosServer.mentos.model.dto.PostMentoringRes;
+import MentosServer.mentos.service.MentoringService;
+import MentosServer.mentos.utils.JwtService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static MentosServer.mentos.config.BaseResponseStatus.POST_MENTORING_SAME_MENTOMENTI;
+
+@RestController
+@RequestMapping("/mentoring")
+public class MentoringController {
+    //final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final MentoringService mentoringService;
+    private final JwtService jwtService;
+
+    @Autowired
+    public MentoringController(MentoringService mentoringService, JwtService jwtService) {
+        this.mentoringService = mentoringService;
+        this.jwtService = jwtService;
+    }
+
+    /**
+     * 멘토링 등록 API
+     * @param postMentoringReq
+     * @return PostMentoringRes => 멘토링 등록 ID, 멘토 ID, 멘티 ID
+     *
+     */
+    @ResponseBody
+    @PostMapping("/registration")
+    public BaseResponse<PostMentoringRes> createMentoring(@Valid @RequestBody PostMentoringReq postMentoringReq, BindingResult br){
+        if(br.hasErrors()){
+            String errorName = br.getAllErrors().get(0).getDefaultMessage();
+            return new BaseResponse<>(BaseResponseStatus.of(errorName));
+        }
+
+        if(postMentoringReq.getMentoId() == postMentoringReq.getMentiId()){ //멘토와 멘티 같은 유저인지 확인
+            return new BaseResponse<>(POST_MENTORING_SAME_MENTOMENTI);
+        }
+
+        try{
+            int memberIdByJwt = jwtService.getMemberId();
+            postMentoringReq.setMentiId(memberIdByJwt);
+
+            PostMentoringRes postMentoringRes = mentoringService.createMentoring(postMentoringReq);
+            return new BaseResponse<>(postMentoringRes);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/controller/MentoringController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentoringController.java
@@ -3,6 +3,7 @@ package MentosServer.mentos.controller;
 import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.config.BaseResponse;
 import MentosServer.mentos.config.BaseResponseStatus;
+import MentosServer.mentos.model.dto.PatchStopMentoringRes;
 import MentosServer.mentos.model.dto.PostAcceptMentoringRes;
 import MentosServer.mentos.model.dto.PostMentoringReq;
 import MentosServer.mentos.model.dto.PostMentoringRes;
@@ -46,13 +47,11 @@ public class MentoringController {
 
         try{
             int memberIdByJwt = jwtService.getMemberId();
-
             if(memberIdByJwt == postMentoringReq.getMentoId()){ //멘토와 멘티 같은 유저인지 확인
                 return new BaseResponse<>(POST_MENTORING_SAME_MENTOMENTI);
             }
 
             postMentoringReq.setMentiId(memberIdByJwt);
-
             PostMentoringRes postMentoringRes = mentoringService.createMentoring(postMentoringReq);
             return new BaseResponse<>(postMentoringRes);
         } catch (BaseException e){
@@ -73,6 +72,24 @@ public class MentoringController {
             PostAcceptMentoringRes postAcceptMentoringRes = mentoringService.acceptMentoring(mentoringId, mentoIdByJwt, acceptance);
 
             return new BaseResponse<>(postAcceptMentoringRes);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 멘토링 강제 종료 API
+     * @param mentoringId
+     * @return
+     */
+    @ResponseBody
+    @PatchMapping("/stop")
+    public BaseResponse<PatchStopMentoringRes> stopMentoring(@RequestParam("mentoringId") int mentoringId){
+        try{
+            int mentiByJwt = jwtService.getMemberId();
+            PatchStopMentoringRes patchStopMentoringRes = mentoringService.stopMentoring(mentoringId, mentiByJwt);
+
+            return new BaseResponse<>(patchStopMentoringRes);
         } catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/MentosServer/mentos/controller/MentoringController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentoringController.java
@@ -20,7 +20,7 @@ import static MentosServer.mentos.config.BaseResponseStatus.POST_MENTORING_SAME_
 @RestController
 @RequestMapping("/mentoring")
 public class MentoringController {
-    //final Logger logger = LoggerFactory.getLogger(this.getClass());
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final MentoringService mentoringService;
     private final JwtService jwtService;
 
@@ -44,12 +44,13 @@ public class MentoringController {
             return new BaseResponse<>(BaseResponseStatus.of(errorName));
         }
 
-        if(postMentoringReq.getMentoId() == postMentoringReq.getMentiId()){ //멘토와 멘티 같은 유저인지 확인
-            return new BaseResponse<>(POST_MENTORING_SAME_MENTOMENTI);
-        }
-
         try{
             int memberIdByJwt = jwtService.getMemberId();
+
+            if(memberIdByJwt == postMentoringReq.getMentoId()){ //멘토와 멘티 같은 유저인지 확인
+                return new BaseResponse<>(POST_MENTORING_SAME_MENTOMENTI);
+            }
+
             postMentoringReq.setMentiId(memberIdByJwt);
 
             PostMentoringRes postMentoringRes = mentoringService.createMentoring(postMentoringReq);

--- a/src/main/java/MentosServer/mentos/controller/MentoringController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentoringController.java
@@ -3,10 +3,7 @@ package MentosServer.mentos.controller;
 import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.config.BaseResponse;
 import MentosServer.mentos.config.BaseResponseStatus;
-import MentosServer.mentos.model.dto.PatchStopMentoringRes;
-import MentosServer.mentos.model.dto.PostAcceptMentoringRes;
-import MentosServer.mentos.model.dto.PostMentoringReq;
-import MentosServer.mentos.model.dto.PostMentoringRes;
+import MentosServer.mentos.model.dto.*;
 import MentosServer.mentos.service.MentoringService;
 import MentosServer.mentos.utils.JwtService;
 import org.slf4j.Logger;
@@ -107,6 +104,26 @@ public class MentoringController {
             int mentiByJwt = jwtService.getMemberId();
             mentoringService.deleteMentoring(mentoringId, mentiByJwt);
             return new BaseResponse<>("멘토링 요청이 취소되었습니다.");
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 멘토,멘티 닉네임 조회 API
+     * @param mentoId
+     * @return
+     */
+    @ResponseBody
+    @GetMapping("/registration/nickname")
+    public BaseResponse<GetNicknameRes> getNickname(@RequestParam("mentoId") int mentoId){
+        try{
+            int mentiByJwt = jwtService.getMemberId();
+            if(mentiByJwt == mentoId){ //멘토와 멘티 같은 유저인지 확인
+                return new BaseResponse<>(POST_MENTORING_SAME_MENTOMENTI);
+            }
+            GetNicknameRes getNicknameRes = mentoringService.getNickname(mentoId, mentiByJwt);
+            return new BaseResponse<>(getNicknameRes);
         } catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/MentosServer/mentos/model/domain/Mentoring.java
+++ b/src/main/java/MentosServer/mentos/model/domain/Mentoring.java
@@ -1,0 +1,20 @@
+package MentosServer.mentos.model.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@AllArgsConstructor
+public class Mentoring {
+    private int mentoringId;
+    private int mentoringCount;
+    private int majorCategoryId;
+    private int mentoringMentos;
+    private int mentoringMentoId;
+    private int mentoringMentiId;
+    private int mentoringStatus;
+    private Timestamp mentoringCreateAt;
+    private Timestamp mentoringUpdateAt;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetNicknameRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetNicknameRes.java
@@ -1,0 +1,13 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetNicknameRes {
+    private String mentoNickname;
+    private String mentiNickname;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PatchStopMentoringRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PatchStopMentoringRes.java
@@ -1,0 +1,12 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PatchStopMentoringRes {
+    private int mentorindId;
+    private int mentiId;
+    private String status;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostAcceptMentoringRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostAcceptMentoringRes.java
@@ -1,0 +1,12 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PostAcceptMentoringRes {
+    private int mentoringId;
+    private int mentoId;
+    private String status;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostMentoringReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostMentoringReq.java
@@ -1,0 +1,33 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Value;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import javax.validation.constraints.*;
+
+@Data
+@AllArgsConstructor
+public class PostMentoringReq {
+    @NotNull(message = "POST_MENTORING_EMPTY_MENTOID")
+    @Min(value = 1, message = "POST_MENTORING_INVALID_MENTOID")
+    private int mentoId; //멘토의 memberId
+
+    @NotNull(message = "POST_MENTORING_EMPTY_MENTIID")
+    private int mentiId = 0; //멘티의 memberId
+
+    @NotNull(message = "POST_MENTORING_EMPTY_MENTORINGCOUNT")
+    @Min(value = 1, message = "POST_MENTORING_LESS_MENTORINGCOUNT")
+    @Max(value = 10, message = "POST_MENTORING_GERATER_MENTORINGCOUNT")
+    private int mentoringCount;
+
+    @NotNull(message = "POST_MENTORING_EMPTY_MAJORCATEGORYID")
+    @Min(value = 1, message = "POST_MENTORING_INVALID_MAJORCATEGORYID")
+    private int majorCategoryId;
+
+    @NotNull(message = "POST_MENTORING_EMPTY_MENTOS")
+    private int mentos;
+
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostMentoringReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostMentoringReq.java
@@ -1,33 +1,25 @@
 package MentosServer.mentos.model.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
-import lombok.Value;
-import org.springframework.boot.context.properties.bind.DefaultValue;
 
 import javax.validation.constraints.*;
 
 @Data
 @AllArgsConstructor
 public class PostMentoringReq {
-    @NotNull(message = "POST_MENTORING_EMPTY_MENTOID")
-    @Min(value = 1, message = "POST_MENTORING_INVALID_MENTOID")
+    @Positive(message = "POST_MENTORING_INVALID_MENTOID")
     private int mentoId; //멘토의 memberId
 
-    @NotNull(message = "POST_MENTORING_EMPTY_MENTIID")
     private int mentiId = 0; //멘티의 memberId
 
-    @NotNull(message = "POST_MENTORING_EMPTY_MENTORINGCOUNT")
     @Min(value = 1, message = "POST_MENTORING_LESS_MENTORINGCOUNT")
     @Max(value = 10, message = "POST_MENTORING_GERATER_MENTORINGCOUNT")
     private int mentoringCount;
 
-    @NotNull(message = "POST_MENTORING_EMPTY_MAJORCATEGORYID")
-    @Min(value = 1, message = "POST_MENTORING_INVALID_MAJORCATEGORYID")
+    @Positive(message = "POST_MENTORING_INVALID_MAJORCATEGORYID")
     private int majorCategoryId;
 
-    @NotNull(message = "POST_MENTORING_EMPTY_MENTOS")
+    @PositiveOrZero(message = "POST_MENTORING_INVALID_MENTOS")
     private int mentos;
-
 }

--- a/src/main/java/MentosServer/mentos/model/dto/PostMentoringRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostMentoringRes.java
@@ -1,0 +1,12 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PostMentoringRes {
+    private int mentoringId;
+    private int mentoId; //멘토의 memberId
+    private int mentiId; //멘티의 memberId
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostProfileReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostProfileReq.java
@@ -2,11 +2,8 @@ package MentosServer.mentos.model.dto;
 
 import lombok.*;
 
-@Getter
-@Setter
+@Data
 @AllArgsConstructor
-@RequiredArgsConstructor
-@NoArgsConstructor
 public class PostProfileReq {
     @NonNull
     private int role;//멘토=1 or 멘티=2
@@ -15,9 +12,7 @@ public class PostProfileReq {
     @NonNull
     private int majorFirst;
     private int majorSecond;
-    private int majorThird;
     @NonNull
     private String introduction;
     private String imageUrl;
-
 }

--- a/src/main/java/MentosServer/mentos/model/dto/PostProfileRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostProfileRes.java
@@ -1,0 +1,11 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PostProfileRes {
+    private int memberId;
+    private String profile;
+}

--- a/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
@@ -1,0 +1,28 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.model.dto.PostMentoringReq;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class MentoringRepository {
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource){
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    //멘토링 등록
+    public int createMentoring(PostMentoringReq postMentoringReq){
+        String query = "insert into MENTORING(mentoringCount, majorCategoryId, mentoringMentos, mentoringMentoId, mentoringMentiId) values(?,?,?,?,?)";
+        Object[] params = new Object[]{postMentoringReq.getMentoringCount(), postMentoringReq.getMajorCategoryId(), postMentoringReq.getMentos(), postMentoringReq.getMentoId(), postMentoringReq.getMentiId()};
+        this.jdbcTemplate.update(query, params);
+
+        String lastInsertIdQuery = "select last_insert_id()";
+        return this.jdbcTemplate.queryForObject(lastInsertIdQuery, int.class);
+    }
+}

--- a/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
@@ -1,5 +1,6 @@
 package MentosServer.mentos.repository;
 
+import MentosServer.mentos.model.domain.Mentoring;
 import MentosServer.mentos.model.dto.PostMentoringReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -33,6 +34,13 @@ public class MentoringRepository {
         return this.jdbcTemplate.queryForObject(query, int.class, params);
     }
 
+    //멘토링 진행 중인 상태인지 확인
+    public int checkProceedingMentoring(int mentoId, int mentiId, int categoryId){
+        String query = "select mentoringId from MENTORING where mentoringMentoId=? and mentoringMentiId=? and majorCategoryId=? and mentoringStatus=1";
+        Object[] params = new Object[]{mentoId, mentiId, categoryId};
+        return this.jdbcTemplate.queryForObject(query, int.class, params);
+    }
+
     //멘토가 멘토링 수락/거절 시 유효 멘토링 존재 여부 확인
     public int checkMentoringByMento(int mentoringId, int mentoId){
         String query = "select exists (select mentoringId from MENTORING where mentoringId=? and mentoringMentoId=? and mentoringStatus=0)";
@@ -44,14 +52,14 @@ public class MentoringRepository {
     public int acceptMentoring(int mentoringId){
         String query = "update MENTORING set mentoringStatus=1 where mentoringId=?";
         int param = mentoringId;
-        return jdbcTemplate.update(query, param);
+        return this.jdbcTemplate.update(query, param);
     }
 
     //멘토링 요청 거절
-    public int rejectMentoring(int mentoringId){
+    public int deleteMentoring(int mentoringId){
         String query = "delete from MENTORING where mentoringId=?";
         int param = mentoringId;
-        return jdbcTemplate.update(query, param);
+        return this.jdbcTemplate.update(query, param);
     }
 
     //멘티가 멘토링 강제 종료시 유효 멘토링 존재 여부 확인
@@ -65,6 +73,32 @@ public class MentoringRepository {
     public int stopMentoring(int mentoringId){
         String query = "update MENTORING set mentoringStatus=2 where mentoringId=?";
         int param = mentoringId;
-        return jdbcTemplate.update(query, param);
+        return this.jdbcTemplate.update(query, param);
+    }
+
+    //멘토링 정보
+    public Mentoring getMentoring(int mentoringId){
+        String query = "select * from MENTORING where mentoringId = ?";
+        int param = mentoringId;
+        return this.jdbcTemplate.queryForObject(query,
+                ((rs, rowNum) -> new Mentoring(
+                        rs.getInt("mentoringId"),
+                        rs.getInt("mentoringCount"),
+                        rs.getInt("majorCategoryId"),
+                        rs.getInt("mentoringMentos"),
+                        rs.getInt("mentoringMentoId"),
+                        rs.getInt("mentoringMentiId"),
+                        rs.getInt("mentoringStatus"),
+                        rs.getTimestamp("mentoringCreateAt"),
+                        rs.getTimestamp("mentoringUpdateAt")
+                )),
+                param);
+    }
+
+    //멘토링 추가 진행
+    public int addMentoring(Mentoring mentoring, int mentoringId){
+        String query = "update MENTORING set mentoringCount = mentoringCount+?, mentoringMentos = mentoringMentos+? where mentoringId=?";
+        Object[] params = new Object[]{mentoring.getMentoringCount(), mentoring.getMentoringMentos(), mentoringId};
+        return this.jdbcTemplate.update(query, params);
     }
 }

--- a/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
@@ -32,4 +32,25 @@ public class MentoringRepository {
         Object[] params = new Object[]{postMentoringReq.getMentoId(), postMentoringReq.getMentiId(), postMentoringReq.getMajorCategoryId()};
         return this.jdbcTemplate.queryForObject(query, int.class, params);
     }
+
+    //멘토링 수락/거절 시 유효 멘토링 존재 여부 확인
+    public int checkMentoringByMento(int mentoringId, int mentoId){
+        String query = "select exists (select mentoringId from MENTORING where mentoringId=? and mentoringMentoId=? and mentoringStatus=0)";
+        Object[] params = new Object[]{mentoringId, mentoId};
+        return this.jdbcTemplate.queryForObject(query, int.class, params);
+    }
+
+    //멘토링 요청 수락
+    public int acceptMentoring(int mentoringId){
+        String query = "update MENTORING set mentoringStatus=1 where mentoringId=?";
+        int param = mentoringId;
+        return jdbcTemplate.update(query, param);
+    }
+
+    //멘토링 요청 거절
+    public int rejectMentoring(int mentoringId){
+        String query = "delete from MENTORING where mentoringId=?";
+        int param = mentoringId;
+        return jdbcTemplate.update(query, param);
+    }
 }

--- a/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
@@ -25,4 +25,11 @@ public class MentoringRepository {
         String lastInsertIdQuery = "select last_insert_id()";
         return this.jdbcTemplate.queryForObject(lastInsertIdQuery, int.class);
     }
+
+    //멘토링 중복 확인
+    public int checkMentoring(PostMentoringReq postMentoringReq){
+        String query = "select exists (select mentoringId from MENTORING where mentoringmentoId=? and mentoringmentiId=? and majorCategoryId=? and mentoringStatus=0)";
+        Object[] params = new Object[]{postMentoringReq.getMentoId(), postMentoringReq.getMentiId(), postMentoringReq.getMajorCategoryId()};
+        return this.jdbcTemplate.queryForObject(query, int.class, params);
+    }
 }

--- a/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
@@ -101,4 +101,11 @@ public class MentoringRepository {
         Object[] params = new Object[]{mentoring.getMentoringCount(), mentoring.getMentoringMentos(), mentoringId};
         return this.jdbcTemplate.update(query, params);
     }
+
+    // 멘토,멘티 닉네임 가져오기
+    public String getNickname(int memberId){
+        String query = "select memberNickName from MEMBER where memberId = ?";
+        int param = memberId;
+        return this.jdbcTemplate.queryForObject(query, String.class, param);
+    }
 }

--- a/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
@@ -33,7 +33,7 @@ public class MentoringRepository {
         return this.jdbcTemplate.queryForObject(query, int.class, params);
     }
 
-    //멘토링 수락/거절 시 유효 멘토링 존재 여부 확인
+    //멘토가 멘토링 수락/거절 시 유효 멘토링 존재 여부 확인
     public int checkMentoringByMento(int mentoringId, int mentoId){
         String query = "select exists (select mentoringId from MENTORING where mentoringId=? and mentoringMentoId=? and mentoringStatus=0)";
         Object[] params = new Object[]{mentoringId, mentoId};
@@ -50,6 +50,20 @@ public class MentoringRepository {
     //멘토링 요청 거절
     public int rejectMentoring(int mentoringId){
         String query = "delete from MENTORING where mentoringId=?";
+        int param = mentoringId;
+        return jdbcTemplate.update(query, param);
+    }
+
+    //멘티가 멘토링 강제 종료시 유효 멘토링 존재 여부 확인
+    public int checkMentoringByMenti(int mentoringId, int mentiId){
+        String query = "select exists (select mentoringId from MENTORING where mentoringId=? and mentoringMentiId=? and mentoringStatus=1)";
+        Object[] params = new Object[]{mentoringId, mentiId};
+        return this.jdbcTemplate.queryForObject(query, int.class, params);
+    }
+
+    //멘토링 강제 종료
+    public int stopMentoring(int mentoringId){
+        String query = "update MENTORING set mentoringStatus=2 where mentoringId=?";
         int param = mentoringId;
         return jdbcTemplate.update(query, param);
     }

--- a/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentoringRepository.java
@@ -63,9 +63,9 @@ public class MentoringRepository {
     }
 
     //멘티가 멘토링 강제 종료시 유효 멘토링 존재 여부 확인
-    public int checkMentoringByMenti(int mentoringId, int mentiId){
-        String query = "select exists (select mentoringId from MENTORING where mentoringId=? and mentoringMentiId=? and mentoringStatus=1)";
-        Object[] params = new Object[]{mentoringId, mentiId};
+    public int checkMentoringByMenti(int mentoringId, int mentiId, int status){
+        String query = "select exists (select mentoringId from MENTORING where mentoringId=? and mentoringMentiId=? and mentoringStatus=?)";
+        Object[] params = new Object[]{mentoringId, mentiId, status};
         return this.jdbcTemplate.queryForObject(query, int.class, params);
     }
 

--- a/src/main/java/MentosServer/mentos/repository/ProfileRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/ProfileRepository.java
@@ -18,15 +18,15 @@ public class ProfileRepository {
 
     //멘토 프로필 등록
     public int createMentoProfile(PostProfileReq postProfileReq){
-        String query = "insert into MENTO(memberId, mentoMajorFirst, mentoMajorSecond, mentoMajorThird, mentoIntro, mentoImageUrl) values(?,?,?,?,?,?)";
-        Object[] params = new Object[]{postProfileReq.getMemberId(), postProfileReq.getMajorFirst(), postProfileReq.getMajorSecond(), postProfileReq.getMajorThird(), postProfileReq.getIntroduction(), postProfileReq.getImageUrl()};
+        String query = "insert into MENTO(memberId, mentoMajorFirst, mentoMajorSecond, mentoIntro, mentoImage) values(?,?,?,?,?)";
+        Object[] params = new Object[]{postProfileReq.getMemberId(), postProfileReq.getMajorFirst(), postProfileReq.getMajorSecond(), postProfileReq.getIntroduction(), postProfileReq.getImageUrl()};
         return this.jdbcTemplate.update(query, params);
     }
 
     //멘티 프로필 등록
     public int createMentiProfile(PostProfileReq postProfileReq){
-        String query = "insert into MENTI(memberId, mentiMajorFirst, mentiMajorSecond, mentiMajorThird, mentiIntro, mentiImageUrl) values(?,?,?,?,?,?)";
-        Object[] params = new Object[]{postProfileReq.getMemberId(), postProfileReq.getMajorFirst(), postProfileReq.getMajorSecond(), postProfileReq.getMajorThird(), postProfileReq.getIntroduction(), postProfileReq.getImageUrl()};
+        String query = "insert into MENTI(memberId, mentiMajorFirst, mentiMajorSecond, mentiIntro, mentiImage) values(?,?,?,?,?)";
+        Object[] params = new Object[]{postProfileReq.getMemberId(), postProfileReq.getMajorFirst(), postProfileReq.getMajorSecond(), postProfileReq.getIntroduction(), postProfileReq.getImageUrl()};
         return this.jdbcTemplate.update(query, params);
     }
 

--- a/src/main/java/MentosServer/mentos/service/MentoringService.java
+++ b/src/main/java/MentosServer/mentos/service/MentoringService.java
@@ -2,10 +2,7 @@ package MentosServer.mentos.service;
 
 import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.model.domain.Mentoring;
-import MentosServer.mentos.model.dto.PatchStopMentoringRes;
-import MentosServer.mentos.model.dto.PostAcceptMentoringRes;
-import MentosServer.mentos.model.dto.PostMentoringReq;
-import MentosServer.mentos.model.dto.PostMentoringRes;
+import MentosServer.mentos.model.dto.*;
 import MentosServer.mentos.repository.MentoringRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,6 +102,19 @@ public class MentoringService {
             if(mentoringRepository.deleteMentoring(mentoringId) == 0){
                 throw new BaseException(FAILDE_TO_DELETEMENTORING);
             }
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    //멘토&멘티 닉네임 조회
+    public GetNicknameRes getNickname(int mentoId, int mentiId) throws BaseException{
+        try{
+            GetNicknameRes getNicknameRes = new GetNicknameRes();
+            getNicknameRes.setMentoNickname(mentoringRepository.getNickname(mentoId));
+            getNicknameRes.setMentiNickname(mentoringRepository.getNickname(mentiId));
+
+            return getNicknameRes;
         } catch (Exception e){
             throw new BaseException(DATABASE_ERROR);
         }

--- a/src/main/java/MentosServer/mentos/service/MentoringService.java
+++ b/src/main/java/MentosServer/mentos/service/MentoringService.java
@@ -4,13 +4,17 @@ import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.model.dto.PostMentoringReq;
 import MentosServer.mentos.model.dto.PostMentoringRes;
 import MentosServer.mentos.repository.MentoringRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+import static MentosServer.mentos.config.BaseResponseStatus.POST_MENTORING_DUPLICATED_MENTORING;
 
 @Service
 public class MentoringService {
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final MentoringRepository mentoringRepository;
 
     @Autowired
@@ -20,9 +24,14 @@ public class MentoringService {
 
     //멘토링 등록
     public PostMentoringRes createMentoring(PostMentoringReq postMentoringReq) throws BaseException {
+        if(checkMentoring(postMentoringReq) == 1){ // 멘토링 중복 신청 확인
+            throw new BaseException(POST_MENTORING_DUPLICATED_MENTORING);
+        }
+
         try{
             int mentoringId = mentoringRepository.createMentoring(postMentoringReq);
             PostMentoringRes postMentoringRes = new PostMentoringRes(mentoringId, postMentoringReq.getMentoId(), postMentoringReq.getMentiId());
+            logger.info("멘토링 신청");
 
             return postMentoringRes;
         } catch (Exception e){
@@ -30,4 +39,12 @@ public class MentoringService {
         }
     }
 
+    //멘토링 중복 체크
+    public int checkMentoring(PostMentoringReq postMentoringReq) throws BaseException{
+        try{
+            return mentoringRepository.checkMentoring(postMentoringReq);
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
 }

--- a/src/main/java/MentosServer/mentos/service/MentoringService.java
+++ b/src/main/java/MentosServer/mentos/service/MentoringService.java
@@ -25,25 +25,17 @@ public class MentoringService {
 
     //멘토링 등록
     public PostMentoringRes createMentoring(PostMentoringReq postMentoringReq) throws BaseException {
-        if(checkMentoring(postMentoringReq) == 1){ // 멘토링 중복 신청 확인
+        if(mentoringRepository.checkMentoring(postMentoringReq) == 1){ // 멘토링 중복 신청 확인
             throw new BaseException(POST_MENTORING_DUPLICATED_MENTORING);
         }
 
         try{
             int mentoringId = mentoringRepository.createMentoring(postMentoringReq);
+
             PostMentoringRes postMentoringRes = new PostMentoringRes(mentoringId, postMentoringReq.getMentoId(), postMentoringReq.getMentiId());
             logger.info("멘토링 신청");
 
             return postMentoringRes;
-        } catch (Exception e){
-            throw new BaseException(DATABASE_ERROR);
-        }
-    }
-
-    //멘토링 중복 체크
-    public int checkMentoring(PostMentoringReq postMentoringReq) throws BaseException{
-        try{
-            return mentoringRepository.checkMentoring(postMentoringReq);
         } catch (Exception e){
             throw new BaseException(DATABASE_ERROR);
         }

--- a/src/main/java/MentosServer/mentos/service/MentoringService.java
+++ b/src/main/java/MentosServer/mentos/service/MentoringService.java
@@ -32,7 +32,6 @@ public class MentoringService {
             int mentoringId = mentoringRepository.createMentoring(postMentoringReq);
 
             PostMentoringRes postMentoringRes = new PostMentoringRes(mentoringId, postMentoringReq.getMentoId(), postMentoringReq.getMentiId());
-            logger.info("멘토링 신청");
 
             return postMentoringRes;
         } catch (Exception e){

--- a/src/main/java/MentosServer/mentos/service/MentoringService.java
+++ b/src/main/java/MentosServer/mentos/service/MentoringService.java
@@ -1,6 +1,7 @@
 package MentosServer.mentos.service;
 
 import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.dto.PatchStopMentoringRes;
 import MentosServer.mentos.model.dto.PostAcceptMentoringRes;
 import MentosServer.mentos.model.dto.PostMentoringReq;
 import MentosServer.mentos.model.dto.PostMentoringRes;
@@ -70,6 +71,24 @@ public class MentoringService {
             }
 
             return postAcceptMentoringRes;
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    //멘토링 강제 종료
+    public PatchStopMentoringRes stopMentoring(int mentoringId, int mentiId) throws BaseException{
+        if(mentoringRepository.checkMentoringByMenti(mentoringId, mentiId) == 0){
+            throw new BaseException(PATCH_INVALID_MENTORING);
+        }
+
+        try{
+            if(mentoringRepository.stopMentoring(mentoringId) == 0){
+                throw new BaseException(FAILED_TO_STOPMENTORING);
+            }
+
+            PatchStopMentoringRes patchStopMentoringRes = new PatchStopMentoringRes(mentoringId, mentiId, "멘토링이 강제 종료 되었습니다.");
+            return patchStopMentoringRes;
         } catch (Exception e){
             throw new BaseException(DATABASE_ERROR);
         }

--- a/src/main/java/MentosServer/mentos/service/MentoringService.java
+++ b/src/main/java/MentosServer/mentos/service/MentoringService.java
@@ -1,6 +1,7 @@
 package MentosServer.mentos.service;
 
 import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.dto.PostAcceptMentoringRes;
 import MentosServer.mentos.model.dto.PostMentoringReq;
 import MentosServer.mentos.model.dto.PostMentoringRes;
 import MentosServer.mentos.repository.MentoringRepository;
@@ -9,8 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
-import static MentosServer.mentos.config.BaseResponseStatus.POST_MENTORING_DUPLICATED_MENTORING;
+import static MentosServer.mentos.config.BaseResponseStatus.*;
 
 @Service
 public class MentoringService {
@@ -43,6 +43,33 @@ public class MentoringService {
     public int checkMentoring(PostMentoringReq postMentoringReq) throws BaseException{
         try{
             return mentoringRepository.checkMentoring(postMentoringReq);
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    //멘토링 수락/거절
+    public PostAcceptMentoringRes acceptMentoring(int mentoringId, int mentoId, Boolean acceptance) throws BaseException{
+        if(mentoringRepository.checkMentoringByMento(mentoringId, mentoId) == 0){ //멘토링 요청 존재 확인
+            throw new BaseException(POST_INVALID_MENTORING);
+        }
+
+        try{
+            PostAcceptMentoringRes postAcceptMentoringRes = new PostAcceptMentoringRes(mentoringId, mentoId, "");
+            if(acceptance){
+                if(mentoringRepository.acceptMentoring(mentoringId) == 0){
+                    throw new BaseException(FAILED_TO_ACCEPTMENTORING);
+                }
+                postAcceptMentoringRes.setStatus("성공적으로 멘토링 요청을 수락했습니다.");
+            }
+            else {
+                if(mentoringRepository.rejectMentoring(mentoringId) == 0){
+                    throw new BaseException(FAILED_TO_REJECTMENTORING);
+                }
+                postAcceptMentoringRes.setStatus("성공적으로 멘토링 요청을 거절했습니다.");
+            }
+
+            return postAcceptMentoringRes;
         } catch (Exception e){
             throw new BaseException(DATABASE_ERROR);
         }

--- a/src/main/java/MentosServer/mentos/service/MentoringService.java
+++ b/src/main/java/MentosServer/mentos/service/MentoringService.java
@@ -1,0 +1,33 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.dto.PostMentoringReq;
+import MentosServer.mentos.model.dto.PostMentoringRes;
+import MentosServer.mentos.repository.MentoringRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+
+@Service
+public class MentoringService {
+    private final MentoringRepository mentoringRepository;
+
+    @Autowired
+    public MentoringService(MentoringRepository mentoringRepository) {
+        this.mentoringRepository = mentoringRepository;
+    }
+
+    //멘토링 등록
+    public PostMentoringRes createMentoring(PostMentoringReq postMentoringReq) throws BaseException {
+        try{
+            int mentoringId = mentoringRepository.createMentoring(postMentoringReq);
+            PostMentoringRes postMentoringRes = new PostMentoringRes(mentoringId, postMentoringReq.getMentoId(), postMentoringReq.getMentiId());
+
+            return postMentoringRes;
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/MentosServer/mentos/service/ProfileService.java
+++ b/src/main/java/MentosServer/mentos/service/ProfileService.java
@@ -2,6 +2,7 @@ package MentosServer.mentos.service;
 
 import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.model.dto.PostProfileReq;
+import MentosServer.mentos.model.dto.PostProfileRes;
 import MentosServer.mentos.repository.ProfileRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -18,8 +19,7 @@ public class ProfileService {
     }
 
     //프로필 등록
-    public void createProfile(PostProfileReq postProfileReq) throws BaseException {
-        int result = 0;
+    public PostProfileRes createProfile(PostProfileReq postProfileReq) throws BaseException {
         int exitMento, exitMenti;
 
         try{
@@ -33,19 +33,24 @@ public class ProfileService {
             throw new BaseException(POST_DUPLICATED_PROFILE);
         }
 
+        PostProfileRes postProfileRes = new PostProfileRes(postProfileReq.getMemberId(), "");
         try{
             if ((postProfileReq.getRole() == 1 && exitMento == 0) || ((exitMento != exitMenti) && exitMento == 0)) {//멘토 프로필 생성
-                result = profileRepository.createMentoProfile(postProfileReq);
+                if(profileRepository.createMentoProfile(postProfileReq) == 0){
+                    throw new BaseException(FAILED_TO_SETPROFILE);
+                }
+                postProfileRes.setProfile("멘토 프로필 생성");
             }
             else if ((postProfileReq.getRole() == 2 && exitMenti == 0) || ((exitMento != exitMenti) && exitMento == 1)) {//멘티 프로필 생성
-                result = profileRepository.createMentiProfile(postProfileReq);
+                if(profileRepository.createMentiProfile(postProfileReq) == 0){
+                    throw new BaseException(FAILED_TO_SETPROFILE);
+                }
+                postProfileRes.setProfile("멘티 프로필 생성");
             }
         } catch (Exception e) {
             throw new BaseException(DATABASE_ERROR);
         }
 
-        if(result == 0){
-            throw new BaseException(FAILED_TO_SETPROFILE);
-        }
+        return postProfileRes;
     }
 }


### PR DESCRIPTION
## 멘토링 요청/ 요청 수락 관련 APIs
### API List
- 멘토링 요청 API
- 멘토링 요청 취소 API
- 멘토링 요청 수락/거절 API
- 멘토링 강제 종료 API
- 멘토,멘티 닉네임 조회 API
- 멘토/멘티 프로필 등록 API (수정)

### 멘토링 요청 API
- 멘티가 멘토링 요청하면 status = 0 (요청 상태)

### 멘토링 요청 취소 API
- 멘토링 요청 취소하면 해당 멘토링 요청 mentoring table에서 삭제

### 멘토링 요청 수락/거절 API
- 해당 멘토와 멘토링이 진행 중이지 않은 경우
     - status = 1 (진행 상태)
- 해당 멘토와 멘토링 진행 중인 경우
    1. 진행 중이던 멘토링에 새로 수락된 멘토링의 횟수/멘토스 개수 더 함
    2. major 카테고리가 다른 경우는 새로운 멘토링 방 생성
    3. 수락된 멘토링 요청은 삭제
   
### 멘토링 강제 종료 API
- 진행 중이던 멘토링 강제 종료
- status = 2 (종료 상태) 변경

### 멘토,멘티 닉네임 조회 API
- 멘토링 등록 전 최종 확인 화면에서 멘토와 멘티의 닉네임 return

### 멘토/멘티 프로필 등록 API
- major 카테고리 선택 가능 개수 3개 -> 2개로 수정

### 그 외
BaseResponseStatus.java 이전 코드 위치 잘 못된 부분 변경


### 추후 개선 사항
알람 API 개발 후 알람 부분을 추가해야합니다.
멘토링 요청 API 제플린 요청 부분 마지막 UI(멘토링 진행하기 - 멘토링 시작 버튼8) 확정에 따라 수정이 필요할 수 있습니다.