### PR TITLE
비밀번호 찾기 기능 구현

### DIFF
--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -87,7 +87,7 @@ public enum BaseResponseStatus {
     EMPTY_POST_CONTENTS(false,2412,"게시글 내용을 입력해주세요"),
 
     //[POST]/pwChange
-    EMPTY_TMP_PASSWORD(false,2413,"임시 비밀번호를 입력해주세요"),
+    EMPTY_TMP_PASSWORD(false,2413,"현재 비밀번호를 입력해주세요"),
 
 
 
@@ -113,7 +113,7 @@ public enum BaseResponseStatus {
     PATCH_POST_SUCCESS(true,3405,"게시글 수정을 완료했습니다."),
     //[POST]/password
     SUCESS_SEND_PASSWORD(true,3406,"임시 비밀번호 전송에 성공했습니다."),
-    NOT_EXIST_EMAIL(false,3407,"존재하지 않는 이메일입니다."),
+    NOT_EXIST_EMAIL(false,3407,"존재하지 않는 회원입니다."),
     //[POST]/pwChange
     NOT_SAME_PASSWORD(false, 3408,"현재 비밀번호가 같지 않습니다."),
     SUCESS_CHANGE_PASSWORD(true,3409,"비밀번호 변경에 성공했습니다"),

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -86,6 +86,11 @@ public enum BaseResponseStatus {
     EMPTY_POST_TITLE(false,2411,"게시글 제목을 입력해주세요"),
     EMPTY_POST_CONTENTS(false,2412,"게시글 내용을 입력해주세요"),
 
+    //[POST]/pwChange
+    EMPTY_TMP_PASSWORD(false,2413,"임시 비밀번호를 입력해주세요"),
+
+
+
     /**
      * 3000 : Response 오류
      */
@@ -106,7 +111,12 @@ public enum BaseResponseStatus {
     INVALID_POST_MEMBER(false,3404,"게시글 작성자가 아닙니다"),
     //[PATCH]/board
     PATCH_POST_SUCCESS(true,3405,"게시글 수정을 완료했습니다."),
-
+    //[POST]/password
+    SUCESS_SEND_PASSWORD(true,3406,"임시 비밀번호 전송에 성공했습니다."),
+    NOT_EXIST_EMAIL(false,3407,"존재하지 않는 이메일입니다."),
+    //[POST]/pwChange
+    NOT_SAME_PASSWORD(false, 3408,"현재 비밀번호가 같지 않습니다."),
+    SUCESS_CHANGE_PASSWORD(true,3409,"비밀번호 변경에 성공했습니다"),
     /**
      * ROZY
      * 301 -  400 : Response 오류

--- a/src/main/java/MentosServer/mentos/controller/PasswordController.java
+++ b/src/main/java/MentosServer/mentos/controller/PasswordController.java
@@ -1,0 +1,77 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.config.BaseResponseStatus;
+import MentosServer.mentos.model.dto.PostNewPwReq;
+import MentosServer.mentos.model.dto.PostPasswordReq;
+import MentosServer.mentos.service.PasswordService;
+import MentosServer.mentos.utils.JwtService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static MentosServer.mentos.config.BaseResponseStatus.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/members")
+public class PasswordController {
+
+	private final PasswordService passwordService;
+	private final JwtService jwtService;
+
+	@Autowired
+	public PasswordController(PasswordService passwordService, JwtService jwtService){
+		this.passwordService = passwordService;
+		this.jwtService = jwtService;
+	}
+
+	/**
+	 *
+	 * @param postPasswordReq
+	 * @return
+	 */
+	@PostMapping("/pwInquiry")
+	public BaseResponse sendPwEmail(@Valid @RequestBody PostPasswordReq postPasswordReq, BindingResult br){
+		//validation 추가
+		if(br.hasErrors()){
+			String errorName = br.getAllErrors().get(0).getDefaultMessage();
+			return new BaseResponse<>(BaseResponseStatus.of(errorName));
+		}
+		try {
+			//임시 비밀번호 보내기
+			passwordService.sendEmail(postPasswordReq);
+			return new BaseResponse<>(SUCESS_SEND_PASSWORD);
+		} catch (BaseException exception) {
+			return new BaseResponse<>((exception.getStatus()));
+		}
+	}
+
+	/**
+	 * 설정에서
+	 * 임시 비밀번호가 맞는지 확인
+	 * 새로운 비밀번호로 설정
+	 * @return
+	 */
+	@PostMapping("/pwChange")
+	public BaseResponse changePw(@Valid @RequestBody PostNewPwReq newPwReq, BindingResult br){
+		//validation 추가
+		if(br.hasErrors()){
+			String errorName = br.getAllErrors().get(0).getDefaultMessage();
+			return new BaseResponse<>(BaseResponseStatus.of(errorName));
+		}
+
+		try {
+			int memberIdByJwt = jwtService.getMemberId();
+			passwordService.changePassword(newPwReq, memberIdByJwt);
+			return new BaseResponse<>(SUCESS_CHANGE_PASSWORD);
+		} catch (BaseException exception) {
+			return new BaseResponse<>((exception.getStatus()));
+		}
+	}
+
+}

--- a/src/main/java/MentosServer/mentos/model/domain/Member.java
+++ b/src/main/java/MentosServer/mentos/model/domain/Member.java
@@ -18,9 +18,8 @@ public class Member {
     private String memberEmail;
     private String memberPw;
     private int memberSchoolId;
-    private int memberMajorId;
+    private String memberMajor;
     private String memberSex;
-    private String memberImage;
     private int memberMentos;
     private String memberStatus;
     private Timestamp memberCreateAt;

--- a/src/main/java/MentosServer/mentos/model/dto/PostNewPwReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostNewPwReq.java
@@ -1,0 +1,18 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import static MentosServer.mentos.config.Constant.passwordRegex;
+
+@Data
+public class PostNewPwReq {
+    @NotBlank(message="EMPTY_TMP_PASSWORD")
+    private String tmpPw; //임시 비밀번호
+
+    @NotBlank(message="EMPTY_USER_PASSWORD")
+    @Pattern(regexp=passwordRegex,message="INVALID_USER_PASSWORD")
+    private String newPw; //현재 비밀번호
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostPasswordReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostPasswordReq.java
@@ -10,9 +10,6 @@ import static MentosServer.mentos.config.Constant.nameRegex;
 
 @Data
 public class PostPasswordReq {
-    @NotBlank(message="EMPTY_USER_NAME")
-    @Pattern(regexp=nameRegex,message="EMPTY_USER_NAME")
-    private String memberName; //이름
 
     @NotBlank(message="POST_USERS_EMPTY_EMAIL")
     @Email(message="POST_USERS_INVALID_EMAIL")

--- a/src/main/java/MentosServer/mentos/model/dto/PostPasswordReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostPasswordReq.java
@@ -1,0 +1,20 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import static MentosServer.mentos.config.Constant.nameRegex;
+
+@Data
+public class PostPasswordReq {
+    @NotBlank(message="EMPTY_USER_NAME")
+    @Pattern(regexp=nameRegex,message="EMPTY_USER_NAME")
+    private String memberName; //이름
+
+    @NotBlank(message="POST_USERS_EMPTY_EMAIL")
+    @Email(message="POST_USERS_INVALID_EMAIL")
+    private String memberEmail; //이메일
+}

--- a/src/main/java/MentosServer/mentos/repository/PasswordRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/PasswordRepository.java
@@ -17,9 +17,8 @@ public class PasswordRepository {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
     public int checkEmail(PostPasswordReq req) {
-        String checkEmailQuery = "select exists(select memberId from member where memberEmail =? and memberName=?)";
-        Object params[] = new Object[]{req.getMemberEmail(),req.getMemberName()};
-        return this.jdbcTemplate.queryForObject(checkEmailQuery,int.class,params); //존재하면 1 아니면 0
+        String checkEmailQuery = "select exists(select memberId from member where memberEmail =?)";
+        return this.jdbcTemplate.queryForObject(checkEmailQuery,int.class,req.getMemberEmail()); //존재하면 1 아니면 0
     }
 
     // 비밀번호 설정

--- a/src/main/java/MentosServer/mentos/repository/PasswordRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/PasswordRepository.java
@@ -1,0 +1,59 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.model.domain.Member;
+import MentosServer.mentos.model.dto.PostPasswordReq;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class PasswordRepository {
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+    public int checkEmail(PostPasswordReq req) {
+        String checkEmailQuery = "select exists(select memberId from member where memberEmail =? and memberName=?)";
+        Object params[] = new Object[]{req.getMemberEmail(),req.getMemberName()};
+        return this.jdbcTemplate.queryForObject(checkEmailQuery,int.class,params); //존재하면 1 아니면 0
+    }
+
+    // 비밀번호 설정
+    public void setPw(String AESPw,int memberId){
+        String setPwQuery = "update member set memberPw =?, memberUpdateAt = CURRENT_TIMESTAMP() where memberId=?";
+        Object params[] = new Object[]{AESPw, memberId};
+        this.jdbcTemplate.update(setPwQuery,params);
+    }
+    //이메일로 멤버인덱스 가져오는 함수
+    public int getMemberId(String email){
+        String getMemberIdQuery = "select memberId from member where memberEmail =?";
+        return this.jdbcTemplate.queryForObject(getMemberIdQuery,int.class,email);
+    }
+
+    public Member getMember(int memberId) {
+        String getPwdQuery = "select * from member where memberId = ?"; // 해당 email을 만족하는 User의 정보들을 조회한다.
+        return this.jdbcTemplate.queryForObject(getPwdQuery,
+                (rs, rowNum) -> new Member(
+                        rs.getInt("memberId"),
+                        rs.getString("memberName"),
+                        rs.getString("memberNickName"),
+                        rs.getInt("memberStudentId"),
+                        rs.getString("memberEmail"),
+                        rs.getString("memberPw"),
+                        rs.getInt("memberSchoolId"),
+                        rs.getString("memberMajor"),
+                        rs.getString("memberSex"),
+                        rs.getInt("memberMentos"),
+                        rs.getString("memberStatus"),
+                        rs.getTimestamp("memberCreateAt"),
+                        rs.getTimestamp("memberUpdateAt")
+                ),
+                memberId
+        );
+    }
+
+}

--- a/src/main/java/MentosServer/mentos/service/MailCheckService.java
+++ b/src/main/java/MentosServer/mentos/service/MailCheckService.java
@@ -1,0 +1,9 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+
+public interface MailCheckService<T>{
+    String sendEmail(T req) throws BaseException;
+    String parseEmail(String email);
+    boolean checkEmail(T req);
+}

--- a/src/main/java/MentosServer/mentos/service/PasswordService.java
+++ b/src/main/java/MentosServer/mentos/service/PasswordService.java
@@ -1,0 +1,139 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.secret.Secret;
+import MentosServer.mentos.model.domain.Member;
+import MentosServer.mentos.model.dto.MailDto;
+import MentosServer.mentos.model.dto.PostNewPwReq;
+import MentosServer.mentos.model.dto.PostPasswordReq;
+import MentosServer.mentos.repository.PasswordRepository;
+import MentosServer.mentos.utils.AES128;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+
+import static MentosServer.mentos.config.BaseResponseStatus.*;
+
+@Service
+@Slf4j
+public class PasswordService implements MailCheckService<PostPasswordReq>{
+
+    private final PasswordRepository passwordRepository;
+    private final MailService mailService;
+
+    @Autowired
+    public PasswordService(PasswordRepository passwordRepository, MailService mailService) {
+        this.passwordRepository = passwordRepository;
+        this.mailService = mailService;
+    }
+
+    /**
+     * 이메일이 DB에 있으면 true, 없으면 false
+     * @param req
+     * @return
+     */
+    @Override
+    public boolean checkEmail(PostPasswordReq req) {
+        if(passwordRepository.checkEmail(req)==1){
+            return true;
+        }
+        return false;
+    }
+
+    @Transactional(rollbackFor = {BaseException.class,Exception.class})
+    @Override
+    public String sendEmail(PostPasswordReq req) throws BaseException {
+        //validation - 이메일이 존재하는지 확인
+        if(!checkEmail(req)){
+            throw new BaseException(NOT_EXIST_EMAIL); //존재하지 않으면 에러코드
+        }
+        //존재하면 임시 비밀번호 메일 전송
+        try{
+            //memberId 가져오기
+            int memberId = passwordRepository.getMemberId(req.getMemberEmail());
+            //임시 비밀번호 만들기
+            String randomPw = createRandomPw();
+            log.info(randomPw);
+            //비밀번호 암호화하고 저장하는 함수
+            pwEncrypt(randomPw,memberId);
+            log.info("pwEncrypt");
+            //메일 보내기
+            MailDto mailDto = new MailDto(req.getMemberEmail(), "Mentos 인증번호", randomPw);
+            mailService.mailSend(mailDto);
+            log.info(mailDto.getMessage());
+            return randomPw;
+        }catch(Exception e){
+            throw new BaseException(MAIL_SEND_ERROR); //메일전송 실패 에러
+        }
+    }
+
+    @Transactional(rollbackFor = {BaseException.class,Exception.class})
+    public void pwEncrypt(String password,int memberId) throws BaseException {
+        try {
+            String AESPw = new AES128(Secret.USER_INFO_PASSWORD_KEY).encrypt(password);
+            log.info(AESPw);
+            passwordRepository.setPw(AESPw,memberId); //DB에 저장
+        } catch (Exception ignored){ //암호화 실패한 경우
+            throw new BaseException(PASSWORD_ENCRYPTION_ERROR);
+        }
+    }
+
+    //임시 비밀번호 발급 (소문자, 숫자, 특수문자 포함 10글자)
+    public String createRandomPw() {
+        char[] charSet = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                '!', '@', '#', '$', '%', '^', '&' };
+        StringBuffer sb = new StringBuffer();
+        SecureRandom sr = new SecureRandom();
+        sr.setSeed(System.currentTimeMillis());
+        int idx = 0;
+        int len = charSet.length;
+        for (int i=0; i<10; i++) {
+            idx = sr.nextInt(len);
+            // 강력한 난수를 발생시키기 위해 SecureRandom을 사용한다.
+            sb.append(charSet[idx]);
+        }
+            return sb.toString();
+    }
+
+    @Override
+    public String parseEmail(String email) {
+        // email 뒷 부분만 파싱해서 반환
+        String ret = "";
+        boolean flag = false;
+        for(int i=0; i<email.length(); i++){
+            if(email.charAt(i) == '@') {
+                flag = true;
+                continue;
+            }
+            if(flag) {
+                ret += email.charAt(i);
+            }
+        }
+        return ret;
+    }
+    //---------------새 비밀번호 받는 메소드--------------------------
+
+    @Transactional(rollbackFor = {BaseException.class,Exception.class})
+    public void changePassword(PostNewPwReq newPwReq, int memberIdByJwt) throws BaseException {
+        Member member = passwordRepository.getMember(memberIdByJwt);
+        String password;
+        try {
+            password = new AES128(Secret.USER_INFO_PASSWORD_KEY).decrypt(member.getMemberPw()); // 복호화
+        } catch (Exception ignored) {
+            throw new BaseException(PASSWORD_DECRYPTION_ERROR);
+        }
+
+        if (newPwReq.getTmpPw().equals(password)) { //임시 비말번호가 일치한다면 새 비밀번호로 바꾼다.
+            pwEncrypt(newPwReq.getNewPw(), memberIdByJwt);
+        } else { // 비밀번호가 다르다면 에러메세지를 출력한다.
+            throw new BaseException(NOT_SAME_PASSWORD);
+        }
+
+    }
+
+}

--- a/src/main/java/MentosServer/mentos/service/SignUpService.java
+++ b/src/main/java/MentosServer/mentos/service/SignUpService.java
@@ -39,7 +39,6 @@ public class SignUpService {
         try {
             // 암호화: signUpReq에서 제공받은 비밀번호를 보안을 위해 암호화시켜 DB에 저장합니다.
             // ex) password123 -> dfhsjfkjdsnj4@!$!@chdsnjfwkenjfnsjfnjsd.fdsfaifsadjfjaf
-            logger.info("암호화 로직");
             pwd = new AES128(Secret.USER_INFO_PASSWORD_KEY).encrypt(signUpReq.getMemberPw()); // 암호화코드
             signUpReq.setMemberPw(pwd);
         } catch (Exception ignored) { // 암호화가 실패하였을 경우 에러 발생
@@ -48,7 +47,6 @@ public class SignUpService {
         //실제 비즈니스 로직
         try {
             int memberId = signUpRepository.createMember(signUpReq);
-            logger.info("jwt발급");
             String memberJwt = jwtService.createJwt(memberId);
             return new SignUpRes(memberId,memberJwt);
         } catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.

--- a/src/test/java/MentosServer/mentos/service/PasswordServiceTest.java
+++ b/src/test/java/MentosServer/mentos/service/PasswordServiceTest.java
@@ -1,0 +1,37 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.repository.PasswordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordServiceTest {
+
+    PasswordService passwordService;
+    @Mock
+    PasswordRepository passwordRepository;
+    @Mock
+    MailService mailService;
+
+    @BeforeEach
+    public void setUp(){
+        MockitoAnnotations.openMocks(this);
+        passwordService = new PasswordService(passwordRepository,mailService);
+    }
+
+    //랜덤으로 비밀번호 생성되는지 확인만 하는 테스트 코드
+    @Test
+    void createRandomPwTest() {
+        //given
+        //when
+        String randomPwd = passwordService.createRandomPw();
+        //then
+        System.out.println("randomPwd = " + randomPwd);
+        assertEquals(randomPwd.length(),10);
+    }
+}


### PR DESCRIPTION
### 1. 임시 비밀번호 메일 전송 API
- 로그인 화면에서 비밀번호 찾기를 눌렀을 때의 기능
- ~~이름과~~ 이메일을 입력하면 10자리의 임시 비밀번호를 전송
- DB에 회원 비밀번호를 임시 비밀번호로 변경

### 2. 비밀번호 변경 API
- 설정에서 비밀번호를 변경한다는 상황으로 구현 (플로우를 바꿔야 한다면 추후 수정하겠습니다.)
- jwt와 현재 비밀번호, 새 비밀번호를 전달받음
- 새 비밀번호로 DB에 저장

비밀번호 변경 API의 경우는 플로우 변경사항이 생기면 수정하도록 하겠습니다! 