### PR TITLE
멘토 멘티 메인화면 API 구현

### DIFF
--- a/src/main/java/MentosServer/mentos/controller/MainController.java
+++ b/src/main/java/MentosServer/mentos/controller/MainController.java
@@ -1,0 +1,50 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.GetMenteeMainRes;
+import MentosServer.mentos.model.dto.GetMentorMainRes;
+import MentosServer.mentos.service.MainService;
+import MentosServer.mentos.utils.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MainController {
+
+	private final JwtService jwtService;
+	private final MainService mainService;
+	
+	@Autowired
+	public MainController(JwtService jwtService, MainService mainService) {
+		this.jwtService = jwtService;
+		this.mainService = mainService;
+	}
+	
+	@GetMapping("/mentor/main")
+	public BaseResponse<GetMentorMainRes> mentorMain(){
+		try {
+			// jwt에서 memberId 뽑아내기
+			String memberId = Integer.toString(jwtService.getMemberId());
+			// 멘티 리스트 반환
+			GetMentorMainRes res = mainService.getMenteeList(memberId);
+			return new BaseResponse<>(res);
+		} catch (BaseException exception) {
+			return new BaseResponse<>((exception.getStatus()));
+		}
+	}
+	
+	@GetMapping("/mentee/main")
+	public BaseResponse<GetMenteeMainRes> menteeMain(){
+		try {
+			// jwt에서 memberId 뽑아내기
+			String memberId = Integer.toString(jwtService.getMemberId());
+			// 멘토 리스트 반환
+			GetMenteeMainRes res = mainService.getMentorList(memberId);
+			return new BaseResponse<>(res);
+		} catch (BaseException exception) {
+			return new BaseResponse<>((exception.getStatus()));
+		}
+	}
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetMenteeMainRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMenteeMainRes.java
@@ -1,0 +1,19 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class GetMenteeMainRes {
+	
+	private int mentos;
+	
+	private List<MainMentorDto> first;
+	
+	private List<MainMentorDto> second;
+	
+	private List<MainMentorDto> third;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetMenteeMainRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMenteeMainRes.java
@@ -11,9 +11,7 @@ public class GetMenteeMainRes {
 	
 	private int mentos;
 	
-	private List<MainMentorDto> first;
+	private List<MentorCategory> MentorCategory;
 	
-	private List<MainMentorDto> second;
-	
-	private List<MainMentorDto> third;
+	private List<MainMentorDto> otherMentor;
 }

--- a/src/main/java/MentosServer/mentos/model/dto/GetMentorMainRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMentorMainRes.java
@@ -1,0 +1,20 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class GetMentorMainRes {
+
+	private int mentos;
+	
+	private List<MainMenteeDto> first;
+	
+	private List<MainMenteeDto> second;
+	
+	private List<MainMenteeDto> third;
+	
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MainDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MainDto.java
@@ -1,0 +1,17 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MainDto {
+	
+	private String schoolId;
+	
+	private int mentos;
+	
+	private int majorFirst;
+	
+	private int majorSecond;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MainMenteeDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MainMenteeDto.java
@@ -1,0 +1,21 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MainMenteeDto {
+	
+	private String nickName;
+	
+	private String menteeMajor; // 입력한 전공
+	
+	private String menteeImage;
+	
+	private String menteeStudentId; // 학번
+	
+	private String firstMajorCategory;
+	
+	private String secondMajorCategory;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MainMenteeDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MainMenteeDto.java
@@ -13,9 +13,11 @@ public class MainMenteeDto {
 	
 	private String menteeImage;
 	
-	private String menteeStudentId; // 학번
+	private String menteeYear; // 학번
 	
-	private String firstMajorCategory;
+	private int menteeStudentId; // 멘티 Id
 	
-	private String secondMajorCategory;
+	private int firstMajorCategory;
+	
+	private int secondMajorCategory;
 }

--- a/src/main/java/MentosServer/mentos/model/dto/MainMentorDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MainMentorDto.java
@@ -13,13 +13,11 @@ public class MainMentorDto {
 	
 	private String mentorImage;
 	
-	private String menteeStudentId; // 학번
+	private int mentorStudentId; // 글 쓴 멘토 Id
 	
-	private String firstMajorCategory;
+	private int postId; // 해당 글 포스트 id
 	
-	private String secondMajorCategory;
-	
-	private int majorCategoryId; // 글의 카테고리 ID
+	private int postCategoryId; // 글의 카테고리 ID
 	
 	private String postTitle;
 	

--- a/src/main/java/MentosServer/mentos/model/dto/MainMentorDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MainMentorDto.java
@@ -1,0 +1,29 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MainMentorDto {
+	
+	private String nickName;
+	
+	private String mentorMajor; // 입력한 전공
+	
+	private String mentorImage;
+	
+	private String menteeStudentId; // 학번
+	
+	private String firstMajorCategory;
+	
+	private String secondMajorCategory;
+	
+	private int majorCategoryId; // 글의 카테고리 ID
+	
+	private String postTitle;
+	
+	private String postContents;
+	
+	private String postImgUrl;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MenteeCategory.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MenteeCategory.java
@@ -7,12 +7,9 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-public class GetMentorMainRes {
-
-	private int mentos;
+public class MenteeCategory {
 	
-	private List<MenteeCategory> MenteeCategory;
+	private int menteeCategoryId;
 	
-	private List<MainMenteeDto> otherMentee;
-	
+	private List<MainMenteeDto> mentee;
 }

--- a/src/main/java/MentosServer/mentos/model/dto/MentorCategory.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MentorCategory.java
@@ -7,12 +7,9 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
-public class GetMentorMainRes {
-
-	private int mentos;
+public class MentorCategory {
 	
-	private List<MenteeCategory> MenteeCategory;
+	private int mentorCategoryId;
 	
-	private List<MainMenteeDto> otherMentee;
-	
+	private List<MainMentorDto> mentorPost;
 }

--- a/src/main/java/MentosServer/mentos/repository/MainRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MainRepository.java
@@ -1,0 +1,130 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.model.dto.MainDto;
+import MentosServer.mentos.model.dto.MainMenteeDto;
+import MentosServer.mentos.model.dto.MainMentorDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+@Repository
+@Slf4j
+public class MainRepository {
+	
+	private JdbcTemplate jdbcTemplate;
+	
+	@Autowired //readme 참고
+	public void setDataSource(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+	
+	/**
+	 * 멘토의 학교 ID, 선택한 전공들 반환
+	 * @param memberId
+	 * @return
+	 */
+	public MainDto getMentorData(String memberId){
+		// Mento table에 접근해서 가져와야함
+		String query = "select memberSchoolId, memberMentos, mentoMajorFirst, mentoMajorSecond from mento natural join member where memberId = ?";
+		String param = memberId;
+		return this.jdbcTemplate.queryForObject(query,
+				(rs, rowNum) -> new MainDto(
+						Integer.toString(rs.getInt("memberSchoolId")),
+						rs.getInt("memberMentos"),
+						rs.getInt("mentoMajorFirst"),
+						rs.getInt("mentoMajorSecond")
+				),
+				param
+		);
+	}
+	
+	/**
+	 * 멘토와 학교가 같은 멘티 중 선택한 전공이 같은 멘티들 최대 3명 반환
+	 * 이때 update 최신 순으로 정렬
+	 * 멘티의 1 전공 = 멘토의 1전공 or 멘티의 1전공 = 멘토의 2전공
+	 * @param mainDto
+	 * @return
+	 */
+	public List<MainMenteeDto> getMenteeList(MainDto mainDto){ // union
+		String schoolId = mainDto.getSchoolId();
+		String majorFirst = Integer.toString(mainDto.getMajorFirst());
+		String majorSecond = Integer.toString(mainDto.getMajorSecond());
+		
+		String query = "(select * from menti natural join member where memberSchoolId = ? and mentiMajorFirst = ? order by mentiUpdateAt DESC LIMIT 3) " +
+						"UNION " +
+						"(select * from menti natural join member where memberSchoolId = ? and mentiMajorFirst = ? order by mentiUpdateAt DESC LIMIT 3) " +
+						"UNION " +
+						"(select * from menti natural join member where memberSchoolId = ? and mentiMajorFirst != ? and mentiMajorFirst != ? order by mentiUpdateAt DESC LIMIT 3)";
+		Object[] searchParam = new Object[]{schoolId, majorFirst, schoolId, majorSecond, schoolId, majorFirst, majorSecond};
+		
+		return this.jdbcTemplate.query(query,
+				(rs, rowNum) -> new MainMenteeDto(
+						rs.getString("memberNickName"),
+						rs.getString("memberMajor"),
+						rs.getString("mentiImage"),
+						Integer.toString(rs.getInt("memberSchoolId")),
+						Integer.toString(rs.getInt("mentiMajorFirst")),
+						Integer.toString(rs.getInt("mentiMajorSecond"))
+				),
+				searchParam
+		);
+	}
+	
+	/**
+	 * 멘티의 학교 ID, 선택한 전공들 반환
+	 * @param memberId
+	 * @return
+	 */
+	public MainDto getMenteeData(String memberId){
+		// Mento table에 접근해서 가져와야함
+		String query = "select memberSchoolId, memberMentos, mentiMajorFirst, mentiMajorSecond from menti natural join member where memberId = ?";
+		String param = memberId;
+		return this.jdbcTemplate.queryForObject(query,
+				(rs, rowNum) -> new MainDto(
+						Integer.toString(rs.getInt("memberSchoolId")),
+						rs.getInt("memberMentos"),
+						rs.getInt("mentiMajorFirst"),
+						rs.getInt("mentiMajorSecond")
+				),
+				param
+		);
+	}
+	
+	/**
+	 * 멘티의 1전공, 2전공, 그외 전공에 관련된 글 최대 3개씩 찾아오기
+	 * @param mainDto
+	 * @return
+	 */
+	public List<MainMentorDto> getMentorList(MainDto mainDto){ // union
+		String schoolId = mainDto.getSchoolId();
+		String majorFirst = Integer.toString(mainDto.getMajorFirst());
+		String majorSecond = Integer.toString(mainDto.getMajorSecond());
+		String query = "(select * from (member natural join mento) natural join (post p left outer join image i on p.postId = i.postId) where memberSchoolId = ? and majorCategoryId = ? order by mentoUpdateAt DESC LIMIT 3) " +
+				"UNION " +
+				"(select * from (member natural join mento) natural join (post p left outer join image i on p.postId = i.postId) where memberSchoolId = ? and majorCategoryId = ? order by mentoUpdateAt DESC LIMIT 3) " +
+				"UNION " +
+				"(select * from (member natural join mento) natural join (post p left outer join image i on p.postId = i.postId) where memberSchoolId = ? and majorCategoryId != ? and majorCategoryId != ? order by mentoUpdateAt DESC LIMIT 3)";
+		Object[] searchParam = new Object[]{schoolId, majorFirst, schoolId, majorSecond, schoolId, majorFirst, majorSecond};
+		
+		return this.jdbcTemplate.query(query,
+				(rs, rowNum) -> new MainMentorDto(
+						rs.getString("memberNickName"),
+						rs.getString("memberMajor"),
+						rs.getString("mentoImage"),
+						Integer.toString(rs.getInt("memberSchoolId")),
+						Integer.toString(rs.getInt("mentoMajorFirst")),
+						Integer.toString(rs.getInt("mentoMajorSecond")),
+						rs.getInt("majorCategoryId"),
+						rs.getString("postTitle"),
+						rs.getString("postContents"),
+						rs.getString("imageUrl")
+				),
+				searchParam
+		);
+	}
+	
+}

--- a/src/main/java/MentosServer/mentos/repository/MainRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MainRepository.java
@@ -67,8 +67,9 @@ public class MainRepository {
 						rs.getString("memberMajor"),
 						rs.getString("mentiImage"),
 						Integer.toString(rs.getInt("memberSchoolId")),
-						Integer.toString(rs.getInt("mentiMajorFirst")),
-						Integer.toString(rs.getInt("mentiMajorSecond"))
+						rs.getInt("memberId"),
+						rs.getInt("mentiMajorFirst"),
+						rs.getInt("mentiMajorSecond")
 				),
 				searchParam
 		);
@@ -115,9 +116,8 @@ public class MainRepository {
 						rs.getString("memberNickName"),
 						rs.getString("memberMajor"),
 						rs.getString("mentoImage"),
-						Integer.toString(rs.getInt("memberSchoolId")),
-						Integer.toString(rs.getInt("mentoMajorFirst")),
-						Integer.toString(rs.getInt("mentoMajorSecond")),
+						rs.getInt("memberId"),
+						rs.getInt("postId"),
 						rs.getInt("majorCategoryId"),
 						rs.getString("postTitle"),
 						rs.getString("postContents"),

--- a/src/main/java/MentosServer/mentos/service/MainService.java
+++ b/src/main/java/MentosServer/mentos/service/MainService.java
@@ -1,0 +1,59 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.dto.*;
+import MentosServer.mentos.repository.MainRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+
+@Service
+@Slf4j
+public class MainService {
+	
+	private final MainRepository mainRepository;
+	
+	@Autowired
+	public MainService(MainRepository mainRepository) {
+		this.mainRepository = mainRepository;
+	}
+	
+	public GetMentorMainRes getMenteeList(String memberId) throws BaseException{
+		try{
+			MainDto mainDto = mainRepository.getMentorData(memberId);
+			List<MainMenteeDto> menteeList = mainRepository.getMenteeList(mainDto);
+			// 각 멘티들을 전공에 맞게 분할 (First = 멘토 1 전공, Second = 멘토 2전공, Third = 그 외 전공)
+			GetMentorMainRes ret = new GetMentorMainRes(mainDto.getMentos(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+			for(MainMenteeDto mentee : menteeList) {
+				if(mentee.getFirstMajorCategory().equals(Integer.toString(mainDto.getMajorFirst()))) ret.getFirst().add(mentee);
+				else if(mentee.getFirstMajorCategory().equals(Integer.toString(mainDto.getMajorSecond()))) ret.getSecond().add(mentee);
+				else ret.getThird().add(mentee);
+			}
+			return ret;
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+	
+	public GetMenteeMainRes getMentorList(String memberId) throws BaseException {
+		try{
+			MainDto mainDto = mainRepository.getMenteeData(memberId);
+			List<MainMentorDto> mentorList = mainRepository.getMentorList(mainDto);
+			// 각 멘토의 글들을 전공에 맞게 분할 (First = 멘티 1 전공, Second = 멘티 2전공, Third = 그 외 전공)
+			GetMenteeMainRes ret = new GetMenteeMainRes(mainDto.getMentos(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+			for(MainMentorDto mentor : mentorList) {
+				if(mentor.getMajorCategoryId() == mainDto.getMajorFirst()) ret.getFirst().add(mentor);
+				else if(mentor.getMajorCategoryId() == mainDto.getMajorSecond()) ret.getSecond().add(mentor);
+				else ret.getThird().add(mentor);
+			}
+			return ret;
+		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
+			throw new BaseException(DATABASE_ERROR);
+		}
+	}
+}

--- a/src/main/java/MentosServer/mentos/service/MainService.java
+++ b/src/main/java/MentosServer/mentos/service/MainService.java
@@ -27,13 +27,23 @@ public class MainService {
 		try{
 			MainDto mainDto = mainRepository.getMentorData(memberId);
 			List<MainMenteeDto> menteeList = mainRepository.getMenteeList(mainDto);
-			// 각 멘티들을 전공에 맞게 분할 (First = 멘토 1 전공, Second = 멘토 2전공, Third = 그 외 전공)
-			GetMentorMainRes ret = new GetMentorMainRes(mainDto.getMentos(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+			// 각 멘티들을 전공에 맞게 분할 (First = 멘토 1 전공, Second = 멘토 2전공, others = 그 외 전공)
+			GetMentorMainRes ret = new GetMentorMainRes(mainDto.getMentos(), new ArrayList<>(), new ArrayList<>());
+			
+			MenteeCategory first = new MenteeCategory(mainDto.getMajorFirst(), new ArrayList<MainMenteeDto>());
+			MenteeCategory second = new MenteeCategory(mainDto.getMajorSecond(), new ArrayList<MainMenteeDto>());
+			
 			for(MainMenteeDto mentee : menteeList) {
-				if(mentee.getFirstMajorCategory().equals(Integer.toString(mainDto.getMajorFirst()))) ret.getFirst().add(mentee);
-				else if(mentee.getFirstMajorCategory().equals(Integer.toString(mainDto.getMajorSecond()))) ret.getSecond().add(mentee);
-				else ret.getThird().add(mentee);
+				if (mentee.getFirstMajorCategory() == mainDto.getMajorFirst())
+					first.getMentee().add(mentee);
+				else if (mentee.getFirstMajorCategory() == mainDto.getMajorSecond())
+					second.getMentee().add(mentee);
+				else ret.getOtherMentee().add(mentee);
 			}
+			
+			ret.getMenteeCategory().add(first);
+			ret.getMenteeCategory().add(second);
+			
 			return ret;
 		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
 			throw new BaseException(DATABASE_ERROR);
@@ -44,13 +54,21 @@ public class MainService {
 		try{
 			MainDto mainDto = mainRepository.getMenteeData(memberId);
 			List<MainMentorDto> mentorList = mainRepository.getMentorList(mainDto);
-			// 각 멘토의 글들을 전공에 맞게 분할 (First = 멘티 1 전공, Second = 멘티 2전공, Third = 그 외 전공)
-			GetMenteeMainRes ret = new GetMenteeMainRes(mainDto.getMentos(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+			// 각 멘토의 글들을 전공에 맞게 분할 (First = 멘티 1 전공, Second = 멘티 2전공, Other = 그 외 전공)
+			GetMenteeMainRes ret = new GetMenteeMainRes(mainDto.getMentos(), new ArrayList<>(), new ArrayList<>());
+
+			MentorCategory first = new MentorCategory(mainDto.getMajorFirst(), new ArrayList<MainMentorDto>());
+			MentorCategory second = new MentorCategory(mainDto.getMajorSecond(), new ArrayList<MainMentorDto>());
+			
 			for(MainMentorDto mentor : mentorList) {
-				if(mentor.getMajorCategoryId() == mainDto.getMajorFirst()) ret.getFirst().add(mentor);
-				else if(mentor.getMajorCategoryId() == mainDto.getMajorSecond()) ret.getSecond().add(mentor);
-				else ret.getThird().add(mentor);
+				if(mentor.getPostCategoryId() == mainDto.getMajorFirst()) first.getMentorPost().add(mentor);
+				else if(mentor.getPostCategoryId() == mainDto.getMajorSecond()) second.getMentorPost().add(mentor);
+				else ret.getOtherMentor().add(mentor);
 			}
+			
+			ret.getMentorCategory().add(first);
+			ret.getMentorCategory().add(second);
+			
 			return ret;
 		} catch (Exception exception) { // DB에 이상이 있는 경우 에러 메시지를 보냅니다.
 			throw new BaseException(DATABASE_ERROR);


### PR DESCRIPTION
## 멘토 멘티 메인화면 API 구현

멘토 멘티 메인화면을 구현하였습니다.

큰 흐름은 다음과 같습니다.

1) 해당 API 호출 시 jwt와 memberId를 통해 현재 유저의 1,2 전공과 학교 번호를 찾음
2) 1, 2 전공과 그 외 전공에 맞는 멘티 or 멘토 글을 최대 3개씩 찾아서 반환

자세한 사항은 API 명세서에 작성하였습니다.