### PR TITLE
검색 API 반환 JSON 수정

### DIFF
--- a/src/main/java/MentosServer/mentos/controller/MenteeSearchController.java
+++ b/src/main/java/MentosServer/mentos/controller/MenteeSearchController.java
@@ -26,7 +26,7 @@ public class MenteeSearchController {
 		this.menteeSearchService = menteeSearchService;
 	}
 	
-	@GetMapping("/mentee/search")
+	@GetMapping("/mentor/search")
 	public BaseResponse<GetMenteeSearchRes> menteeSearch(@ModelAttribute GetMenteeSearchReq req){
 		try {
 			// jwt에서 memberId 뽑아내기

--- a/src/main/java/MentosServer/mentos/controller/MentorSearchController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentorSearchController.java
@@ -26,7 +26,7 @@ public class MentorSearchController {
 		this.mentorSearchService = mentorSearchService;
 	}
 	
-	@GetMapping("/mentor/search")
+	@GetMapping("/mentee/search")
 	public BaseResponse<GetMentorSearchRes> mentorSearch(@ModelAttribute GetMentorSearchReq req){
 		try {
 			// jwt에서 memberId 뽑아내기

--- a/src/main/java/MentosServer/mentos/model/dto/MenteeSearchDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MenteeSearchDto.java
@@ -7,13 +7,13 @@ import lombok.Data;
 @AllArgsConstructor
 public class MenteeSearchDto {
 	
-	private String mentiId;
+	private int mentiId;
 	
 	private String mentiNickName;
 	
-	private String mentiMajorFirst;
+	private int mentiMajorFirst;
 	
-	private String mentiMajorSecond;
+	private int mentiMajorSecond;
 	
 	private String mentiImage;
 	

--- a/src/main/java/MentosServer/mentos/model/dto/PostDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostDto.java
@@ -2,18 +2,17 @@ package MentosServer.mentos.model.dto;
 
 import lombok.Data;
 
-import java.util.List;
 
 @Data
 public class PostDto {
 	
-	private String postId;
+	private int postId;
 	
-	private String majorCategoryId;
+	private int majorCategoryId;
 	
-	private String mentoId;
+	private int mentoId;
 	
-	private String mentoImage;
+	private String memberMajor;
 	
 	private String mentoNickName;
 	
@@ -21,14 +20,13 @@ public class PostDto {
 	
 	private String postContents;
 	
-	private List<String> imageUrls;
+	private String imageUrl;
 	
-	
-	public PostDto(String postId, String majorCategoryId, String mentoId, String mentoImage, String mentoNickName, String postTitle, String postContents) {
+	public PostDto(int postId, int majorCategoryId, int mentoId, String memberMajor, String mentoNickName, String postTitle, String postContents) {
 		this.postId = postId;
 		this.majorCategoryId = majorCategoryId;
 		this.mentoId = mentoId;
-		this.mentoImage = mentoImage;
+		this.memberMajor = memberMajor;
 		this.mentoNickName = mentoNickName;
 		this.postTitle = postTitle;
 		this.postContents = postContents;

--- a/src/main/java/MentosServer/mentos/model/dto/PostWithProfile.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostWithProfile.java
@@ -17,7 +17,7 @@ public class PostWithProfile implements Comparable<PostWithProfile>{
 	
 	private String memberNickName;
 	
-	private String mentoImage;
+	private String memberMajor;
 	
 	private String postTitle;
 	

--- a/src/main/java/MentosServer/mentos/repository/MentorSearchRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentorSearchRepository.java
@@ -47,7 +47,7 @@ public class MentorSearchRepository {
 	public List<PostWithProfile> getPosts(GetMentorSearchReq req, String schoolId){
 		String arrayToString = String.join(",", req.getMajorFlag());
 		String searchQuery =
-				"select postId, majorCategoryId, memberId, memberNickName, mentoImage, postTitle, postContents, postCreateAt, postUpdateAt " +
+				"select postId, majorCategoryId, memberId, memberNickName, memberMajor, postTitle, postContents, postCreateAt, postUpdateAt " +
 				"from " +
 					"(" +
 					"select * " +
@@ -56,7 +56,6 @@ public class MentorSearchRepository {
 					") T NATURAL JOIN mento " +
 				"where (mentoMajorFirst IN (" + arrayToString + ")" + " OR mentoMajorSecond IN (" + arrayToString + ")) AND " + "(memberNickName LIKE ? OR postTitle LIKE ? OR postContents LIKE ?)";
 		String param = changeParam(req.getSearchText());
-		log.info(searchQuery);
 		Object[] searchParam = new Object[]{param, param, param};
 		return this.jdbcTemplate.query(searchQuery,
 				(rs, rowNum) -> new PostWithProfile(
@@ -64,7 +63,7 @@ public class MentorSearchRepository {
 						rs.getInt("majorCategoryId"),
 						rs.getInt("memberId"),
 						rs.getString("memberNickName"),
-						rs.getString("mentoImage"),
+						rs.getString("memberMajor"),
 						rs.getString("postTitle"),
 						rs.getString("postContents"),
 						rs.getTimestamp("postCreateAt"),
@@ -78,12 +77,11 @@ public class MentorSearchRepository {
 		return "%" + text + "%";
 	}
 	
-	public List<String> getImageUrl(String postId){
+	public List<String> getImageUrl(int postId){
 		String searchImageQuery = "select imageUrl from Image where postId = ?";
-		String searchImageParam = postId;
+		String searchImageParam = Integer.toString(postId);
 		return this.jdbcTemplate.query(searchImageQuery,
-				(rs, rowNum) -> rs.getString("imageUrl")
-				, searchImageParam
-		);
+				(rs, rowNum) -> rs.getString("imageUrl"),
+				searchImageParam);
 	}
 }

--- a/src/main/java/MentosServer/mentos/service/MenteeSearchService.java
+++ b/src/main/java/MentosServer/mentos/service/MenteeSearchService.java
@@ -62,7 +62,7 @@ public class MenteeSearchService {
 		ArrayList<MenteeSearchDto> ret = new ArrayList<MenteeSearchDto>();
 		Collections.sort(arr);
 		for(MenteeWithNickName m : arr){
-			ret.add(new MenteeSearchDto(Integer.toString(m.getMemberId()), m.getMemberNickName(), Integer.toString(m.getMentiMajorFirst()), Integer.toString(m.getMentiMajorSecond()),
+			ret.add(new MenteeSearchDto(m.getMemberId(), m.getMemberNickName(), m.getMentiMajorFirst(), m.getMentiMajorSecond(),
 					m.getMentiImage(), m.getMentiIntro()));
 		}
 		return ret;

--- a/src/main/java/MentosServer/mentos/service/MentorSearchService.java
+++ b/src/main/java/MentosServer/mentos/service/MentorSearchService.java
@@ -62,8 +62,10 @@ public class MentorSearchService {
 	 */
 	private void getImageUrlByPostId(ArrayList<PostDto> postDtos) {
 		for(PostDto post : postDtos) {
-			String postId = post.getPostId();
-			post.setImageUrls(mentorSearchRepository.getImageUrl(postId));
+			int postId = post.getPostId();
+			List<String> imageUrl = mentorSearchRepository.getImageUrl(postId);
+			if(imageUrl.isEmpty()) continue;
+			post.setImageUrl(imageUrl.get(0));
 		}
 	}
 	
@@ -76,8 +78,8 @@ public class MentorSearchService {
 		ArrayList<PostDto> ret = new ArrayList<PostDto>();
 		Collections.sort(arr);
 		for(PostWithProfile p : arr){
-			ret.add(new PostDto(Integer.toString(p.getPostId()), Integer.toString(p.getMajorCategoryId()), Integer.toString(p.getMemberId()),
-					p.getMentoImage(), p.getMemberNickName(), p.getPostTitle(), p.getPostContents()));
+			ret.add(new PostDto(p.getPostId(), p.getMajorCategoryId(), p.getMemberId(), p.getMemberMajor(),
+					p.getMemberNickName(), p.getPostTitle(), p.getPostContents()));
 		}
 		return ret;
 	}


### PR DESCRIPTION
## 검색 API 반환 JSON 수정

안드단에서 요청한 변경사항을 적용하였습니다.

### 멘티 검색(멘티가 멘토 글 검색)
* 멘토쓰 글 image 보낼때 스트링 값으로 (하나만 보내니까)
* 멤버 전공 보내주기(member table의 전공) 
* majorCategoryId 값은 int값으로
* profile image 필요없음 (기본 값 넣을거임)
* postId, mentoId 둘다 int

### 멘토 검색(멘토가 멘티 리스트 검색)
* mentiId, menti 전공들 int로 반환
