### PR TITLE
프로필 조회 APIs, 회원 탈퇴 API

### DIFF
--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -127,6 +127,11 @@ public enum BaseResponseStatus {
     INVALID_MENTEEPROFILE(false, 3303, "해당 유저는 멘티 프로필이 없습니다."),
     INVALID_MENTORPROFILE(false,3304, "해당 유저는 멘토 프로필이 없습니다."),
 
+    //[PATCH] /setting/member-leave
+    INVALID_PASSWORD(false, 3305, "틀린 비밀번호입니다."),
+    FAILED_TO_MEMBERLEAVE(false, 3306, "회원탈퇴에 실패하였습니다."),
+
+
     /**
      * 4000 : Database, Server 오류
      */

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -124,6 +124,8 @@ public enum BaseResponseStatus {
 
     //[POST] /mentoring/registration
     POST_MENTORING_DUPLICATED_MENTORING(false,3302, "해당 멘토에게 수락 요청 대기 중인 멘토링 요청이 있습니다."),
+    INVALID_MENTEEPROFILE(false, 3303, "해당 유저는 멘티 프로필이 없습니다."),
+    INVALID_MENTORPROFILE(false,3304, "해당 유저는 멘토 프로필이 없습니다."),
 
     /**
      * 4000 : Database, Server 오류

--- a/src/main/java/MentosServer/mentos/controller/MemberLeaveController.java
+++ b/src/main/java/MentosServer/mentos/controller/MemberLeaveController.java
@@ -1,0 +1,41 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.PatchMemberLeaveReq;
+import MentosServer.mentos.service.MemberLeaveService;
+import MentosServer.mentos.utils.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/setting")
+public class MemberLeaveController {
+    private final MemberLeaveService memberLeaveService;
+    private final JwtService jwtService;
+
+    @Autowired
+    public MemberLeaveController(MemberLeaveService memberLeaveService, JwtService jwtService){
+        this.memberLeaveService = memberLeaveService;
+        this.jwtService = jwtService;
+    }
+
+    /**
+     * 회원 탈퇴 API
+     * @param patchMemberLeaveReq
+     * @return String
+     */
+    @PatchMapping("/member-leave")
+    public BaseResponse<String> deleteMember(@RequestBody PatchMemberLeaveReq patchMemberLeaveReq){
+        try{
+            int memberIdByJwt = jwtService.getMemberId();
+            memberLeaveService.deleteMember(memberIdByJwt, patchMemberLeaveReq);
+            return new BaseResponse<>("성공적으로 회원탈퇴 되었습니다.");
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/controller/MenteeProfileController.java
+++ b/src/main/java/MentosServer/mentos/controller/MenteeProfileController.java
@@ -1,0 +1,32 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.GetMenteeProfileRes;
+import MentosServer.mentos.service.MenteeProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/profile")
+public class MenteeProfileController {
+    private final MenteeProfileService menteeProfileService;
+
+    @Autowired
+    public MenteeProfileController(MenteeProfileService menteeProfileService){
+        this.menteeProfileService = menteeProfileService;
+    }
+
+    @GetMapping("/mentee")
+    public BaseResponse<GetMenteeProfileRes> getMenteeProfile(@RequestParam int memberId){
+        try{
+            GetMenteeProfileRes getMenteeProfileRes = menteeProfileService.getMenteeProfile(memberId);
+            return new BaseResponse<>(getMenteeProfileRes);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/controller/MentorProfileController.java
+++ b/src/main/java/MentosServer/mentos/controller/MentorProfileController.java
@@ -1,0 +1,32 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.GetMentorProfileRes;
+import MentosServer.mentos.service.MentorProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/profile")
+public class MentorProfileController {
+    private final MentorProfileService mentorProfileService;
+
+    @Autowired
+    public MentorProfileController(MentorProfileService mentorProfileService){
+        this.mentorProfileService = mentorProfileService;
+    }
+
+    @GetMapping("/mentor")
+    public BaseResponse<GetMentorProfileRes> getMentorProfile(@RequestParam int memberId){
+        try{
+            GetMentorProfileRes getMentorProfileRes = mentorProfileService.getMentorProfile(memberId);
+            return new BaseResponse<>(getMentorProfileRes);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/controller/MyPageController.java
+++ b/src/main/java/MentosServer/mentos/controller/MyPageController.java
@@ -1,0 +1,35 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.GetMyPageRes;
+import MentosServer.mentos.service.MyPageService;
+import MentosServer.mentos.utils.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/profile")
+public class MyPageController {
+    private final MyPageService myPageService;
+    private final JwtService jwtService;
+
+    @Autowired
+    public MyPageController(MyPageService myPageService, JwtService jwtService){
+        this.myPageService = myPageService;
+        this.jwtService = jwtService;
+    }
+
+    @GetMapping("/mypage")
+    public BaseResponse<GetMyPageRes> getMyPage(){
+        try{
+            int memberId = jwtService.getMemberId();
+            GetMyPageRes getMyPageRes = myPageService.getMyPage(memberId);
+            return new BaseResponse<>(getMyPageRes);
+        } catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/model/domain/Review.java
+++ b/src/main/java/MentosServer/mentos/model/domain/Review.java
@@ -1,0 +1,16 @@
+package MentosServer.mentos.model.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import java.sql.Timestamp;
+
+@Data
+@AllArgsConstructor
+public class Review {
+    private int reviewId;
+    private int mentoringId;
+    private String reviewText;
+    private double reviewScore;
+    private Timestamp reviewCreateAt;
+    private Timestamp reviewUpdateAt;
+}

--- a/src/main/java/MentosServer/mentos/model/domain/Review.java
+++ b/src/main/java/MentosServer/mentos/model/domain/Review.java
@@ -11,6 +11,4 @@ public class Review {
     private int mentoringId;
     private String reviewText;
     private double reviewScore;
-    private Timestamp reviewCreateAt;
-    private Timestamp reviewUpdateAt;
 }

--- a/src/main/java/MentosServer/mentos/model/dto/GetMenteeProfileRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMenteeProfileRes.java
@@ -1,0 +1,12 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GetMenteeProfileRes {
+    private MenteeProfileDto basicInformation;
+    private String schoolName;
+    private int numOfMentoring;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetMentorProfileRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMentorProfileRes.java
@@ -1,0 +1,18 @@
+package MentosServer.mentos.model.dto;
+
+import MentosServer.mentos.model.domain.Review;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class GetMentorProfileRes {
+    private MentorProfileDto basicInformation;
+    private String schoolName;
+    private int numOfMentoring;
+    private List<PostWithImageDto> posts;
+    private List<Review> reviews;
+    private List<MentosCountDto> numOfMentos;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetMyPageRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMyPageRes.java
@@ -7,5 +7,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class GetMyPageRes {
     private GetMentorProfileRes mentorProfile;
-    private GetMenteeProfileRes menteeProfileRes;
+    private GetMenteeProfileRes menteeProfile;
 }

--- a/src/main/java/MentosServer/mentos/model/dto/GetMyPageRes.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetMyPageRes.java
@@ -1,0 +1,11 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GetMyPageRes {
+    private GetMentorProfileRes mentorProfile;
+    private GetMenteeProfileRes menteeProfileRes;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MenteeProfileDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MenteeProfileDto.java
@@ -1,0 +1,21 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.lang.Nullable;
+
+@Data
+@AllArgsConstructor
+public class MenteeProfileDto {
+    private int memberId;
+    private String name;
+    private String nickname;
+    private int studentId;
+    private int schoolId;
+    private String major;
+    private String sex;
+    private int majorFirst;
+    private int majorSecond;
+    private String profileImage;
+    private String intro;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MentorProfileDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MentorProfileDto.java
@@ -1,0 +1,21 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MentorProfileDto {
+    private int memberId;
+    private String name;
+    private String nickname;
+    private int studentId;
+    private int schoolId;
+    private String major;
+    private String sex;
+    private int majorFirst;
+    private int majorSecond;
+    private String profileImage;
+    private String intro;
+    private double mentoScore;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/MentosCountDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/MentosCountDto.java
@@ -1,0 +1,12 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MentosCountDto {
+    private int mentoringId;
+    private int majorCategoryId;
+    private int mentoringMentos;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PatchMemberLeaveReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PatchMemberLeaveReq.java
@@ -1,0 +1,9 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+public class PatchMemberLeaveReq {
+    private String password;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostWithImageDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostWithImageDto.java
@@ -1,0 +1,28 @@
+package MentosServer.mentos.model.dto;
+
+import MentosServer.mentos.model.domain.Post;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.sql.Timestamp;
+
+@Data
+@AllArgsConstructor
+public class PostWithImageDto {
+    @NotNull
+    private int postId;
+    @NotNull
+    private int majorCategoryId;
+    @NotNull
+    private int memberId;
+    @NotNull
+    private String postTitle;
+    @NotNull
+    private String postContents;
+    @NotNull
+    private Timestamp postCreateAt;
+    @NotNull
+    private Timestamp postUpdateAt;
+    private String ImageUrl;
+}

--- a/src/main/java/MentosServer/mentos/model/dto/PostWithImageDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostWithImageDto.java
@@ -20,9 +20,6 @@ public class PostWithImageDto {
     private String postTitle;
     @NotNull
     private String postContents;
-    @NotNull
-    private Timestamp postCreateAt;
-    @NotNull
-    private Timestamp postUpdateAt;
+
     private String ImageUrl;
 }

--- a/src/main/java/MentosServer/mentos/repository/MemberLeaveRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MemberLeaveRepository.java
@@ -1,0 +1,29 @@
+package MentosServer.mentos.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class MemberLeaveRepository {
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    //비밀번호 가져오기
+    public String getPassword(int memberId){
+        String query = "select memberPw from MEMBER where memberId=?";
+        return this.jdbcTemplate.queryForObject(query, String.class, memberId);
+    }
+
+    //회원탈퇴 => 회원 상태 변경
+    public int modifyMemberStatus(int memberId){
+        String query = "update MEMBER set memberStatus = 'INACTIVE' where memberId=?";
+        return this.jdbcTemplate.update(query, memberId);
+    }
+}

--- a/src/main/java/MentosServer/mentos/repository/MenteeProfileRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MenteeProfileRepository.java
@@ -1,0 +1,59 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.model.dto.MenteeProfileDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class MenteeProfileRepository {
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource){
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    //멘티 프로필 기본 정보 조회
+    public MenteeProfileDto getBasicInfoByMentee(int memberId){
+        String query = "select memberId, memberName, memberNickName, memberStudentId, memberSchoolId, memberMajor, memberSex, mentiMajorFirst, mentiMajorSecond, mentiImage, mentiIntro from MEMBER natural join MENTI where memberId = ?";
+        int param = memberId;
+        return this.jdbcTemplate.queryForObject(query,
+                (rs, rowNum) -> new MenteeProfileDto(
+                        rs.getInt("memberId"),
+                        rs.getString("memberName"),
+                        rs.getString("memberNickName"),
+                        rs.getInt("memberStudentId"),
+                        rs.getInt("memberSchoolId"),
+                        rs.getString("memberMajor"),
+                        rs.getString("memberSex"),
+                        rs.getInt("mentiMajorFirst"),
+                        rs.getInt("mentiMajorSecond"),
+                        rs.getString("mentiImage"),
+                        rs.getString("mentiIntro")
+                ), param);
+    }
+
+    //멘티 프로필 생성 여부 확인
+    public int checkMenteeProfile(int memberId){
+       String query = "select exists (select memberId from MENTI where memberId = ?)";
+       int param = memberId;
+       return this.jdbcTemplate.queryForObject(query, int.class, param);
+    }
+
+    //학교명 조회
+    public String getSchoolName(int schoolId){
+        String query = "select schoolName from SCHOOLCATEGORY where schoolId=?";
+        int param = schoolId;
+        return this.jdbcTemplate.queryForObject(query, String.class, param);
+    }
+
+    //멘티 기준 종료된 멘토링 횟수 조회
+    public int getNumOfMentoringByMentee(int memberId){
+        String query = "select count(mentoringId) from MENTORING where mentoringMentiId = ? and mentoringStatus = 2";
+        int param = memberId;
+        return this.jdbcTemplate.queryForObject(query, int.class, param);
+    }
+}

--- a/src/main/java/MentosServer/mentos/repository/MentorProfileRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentorProfileRepository.java
@@ -65,7 +65,7 @@ public class MentorProfileRepository {
 
     //멘토 작성 post 조회
     public List<PostWithImageDto> getPostsByMemberId(int memberId){
-        String query = "select postId,memberId,majorCategoryId,postTitle,postContents, postCreateAt, postUpdateAt, imageUrl from POST left outer join IMAGE using (postId) where memberId = ?";
+        String query = "select postId,memberId,majorCategoryId,postTitle,postContents, imageUrl from POST left outer join IMAGE using (postId) where memberId = ?";
         int param = memberId;
         return this.jdbcTemplate.query(query,
                 (rs, rowNum) -> new PostWithImageDto(
@@ -74,8 +74,6 @@ public class MentorProfileRepository {
                         rs.getInt("majorCategoryId"),
                         rs.getString("postTitle"),
                         rs.getString("postContents"),
-                        rs.getTimestamp("postCreateAt"),
-                        rs.getTimestamp("postUpdateAt"),
                         rs.getString("imageUrl")
                 ),
                 param);
@@ -83,16 +81,14 @@ public class MentorProfileRepository {
 
     //멘토에 대한 review 조회
     public List<Review> getReviewsOnMentor(int memberId){
-        String query = "select * from REVIEW natural join MENTORING where mentoringMentoId = ?";
+        String query = "select reviewId, mentoringId, reviewText, reviewScore from REVIEW natural join MENTORING where mentoringMentoId = ?";
         int param = memberId;
         return this.jdbcTemplate.query(query,
                 (rs, rowNum) -> new Review(
                         rs.getInt("reviewId"),
                         rs.getInt("mentoringId"),
                         rs.getString("reviewText"),
-                        rs.getDouble("reviewScore"),
-                        rs.getTimestamp("reviewCreateAt"),
-                        rs.getTimestamp("reviewUpdateAt")
+                        rs.getDouble("reviewScore")
                 ),
                 param);
     }

--- a/src/main/java/MentosServer/mentos/repository/MentorProfileRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentorProfileRepository.java
@@ -1,0 +1,112 @@
+package MentosServer.mentos.repository;
+
+import MentosServer.mentos.model.domain.Post;
+import MentosServer.mentos.model.domain.Review;
+import MentosServer.mentos.model.dto.MentorProfileDto;
+import MentosServer.mentos.model.dto.MentosCountDto;
+import MentosServer.mentos.model.dto.PostWithImageDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+@Repository
+public class MentorProfileRepository {
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource){
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    //멘토 프로필 존재 여부 확인
+    public int checkMentorProfile(int memberId){
+        String query = "select exists (select memberId from MENTO where memberId = ?)";
+        int param = memberId;
+        return this.jdbcTemplate.queryForObject(query, int.class, param);
+    }
+
+    //멘토 기본 정보 조회
+    public MentorProfileDto getBasicInfoByMentor(int memberId){
+        String query = "select memberId, memberName, memberNickName, memberStudentId, memberSchoolId, memberMajor, memberSex, mentoMajorFirst, mentoMajorSecond, mentoImage, mentoIntro, mentoScore from MEMBER natural join MENTO where memberId = ?";
+        int param = memberId;
+        return this.jdbcTemplate.queryForObject(query,
+                (rs, rowNum) -> new MentorProfileDto(
+                        rs.getInt("memberId"),
+                        rs.getString("memberName"),
+                        rs.getString("memberNickName"),
+                        rs.getInt("memberStudentId"),
+                        rs.getInt("memberSchoolId"),
+                        rs.getString("memberMajor"),
+                        rs.getString("memberSex"),
+                        rs.getInt("mentoMajorFirst"),
+                        rs.getInt("mentoMajorSecond"),
+                        rs.getString("mentoImage"),
+                        rs.getString("mentoIntro"),
+                        rs.getDouble("mentoScore")
+                ), param);
+    }
+
+    //학교명 조회
+    public String getSchoolName(int schoolId){
+        String query = "select schoolName from SCHOOLCATEGORY where schoolId=?";
+        int param = schoolId;
+        return this.jdbcTemplate.queryForObject(query, String.class, param);
+    }
+
+    //멘토 기준 종료된 멘토링 횟수 조회
+    public int getNumOfMentoringByMentor(int memberId){
+        String query = "select count(mentoringId) from MENTORING where mentoringMentoId = ? and mentoringStatus = 2";
+        int param = memberId;
+        return this.jdbcTemplate.queryForObject(query, int.class, param);
+    }
+
+    //멘토 작성 post 조회
+    public List<PostWithImageDto> getPostsByMemberId(int memberId){
+        String query = "select postId,memberId,majorCategoryId,postTitle,postContents, postCreateAt, postUpdateAt, imageUrl from POST left outer join IMAGE using (postId) where memberId = ?";
+        int param = memberId;
+        return this.jdbcTemplate.query(query,
+                (rs, rowNum) -> new PostWithImageDto(
+                        rs.getInt("postId"),
+                        rs.getInt("memberId"),
+                        rs.getInt("majorCategoryId"),
+                        rs.getString("postTitle"),
+                        rs.getString("postContents"),
+                        rs.getTimestamp("postCreateAt"),
+                        rs.getTimestamp("postUpdateAt"),
+                        rs.getString("imageUrl")
+                ),
+                param);
+    }
+
+    //멘토에 대한 review 조회
+    public List<Review> getReviewsOnMentor(int memberId){
+        String query = "select * from REVIEW natural join MENTORING where mentoringMentoId = ?";
+        int param = memberId;
+        return this.jdbcTemplate.query(query,
+                (rs, rowNum) -> new Review(
+                        rs.getInt("reviewId"),
+                        rs.getInt("mentoringId"),
+                        rs.getString("reviewText"),
+                        rs.getDouble("reviewScore"),
+                        rs.getTimestamp("reviewCreateAt"),
+                        rs.getTimestamp("reviewUpdateAt")
+                ),
+                param);
+    }
+
+    //지금까지 진행한 멘토링(멘토쓰 카테고리+멘토쓰 개수)
+    public List<MentosCountDto> getMentosCount(int memberId){
+        String query = "select mentoringId, majorCategoryId, mentoringMentos from MENTORING where mentoringMentoId = ? and mentoringStatus = 2";
+        int param = memberId;
+        return this.jdbcTemplate.query(query,
+                (rs, rowNum) -> new MentosCountDto(
+                        rs.getInt("mentoringId"),
+                        rs.getInt("majorCategoryId"),
+                        rs.getInt("mentoringMentos")
+                ),
+                param);
+    }
+}

--- a/src/main/java/MentosServer/mentos/service/MemberLeaveService.java
+++ b/src/main/java/MentosServer/mentos/service/MemberLeaveService.java
@@ -1,0 +1,50 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.secret.Secret;
+import MentosServer.mentos.model.dto.PatchMemberLeaveReq;
+import MentosServer.mentos.repository.MemberLeaveRepository;
+import MentosServer.mentos.utils.AES128;
+import MentosServer.mentos.utils.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static MentosServer.mentos.config.BaseResponseStatus.*;
+
+@Service
+public class MemberLeaveService {
+    private final MemberLeaveRepository memberLeaveRepository;
+    private final JwtService jwtService;
+
+    @Autowired
+    public MemberLeaveService(MemberLeaveRepository memberLeaveRepository, JwtService jwtService){
+        this.memberLeaveRepository = memberLeaveRepository;
+        this.jwtService = jwtService;
+    }
+
+    //회원탈퇴
+    public void deleteMember(int memberId, PatchMemberLeaveReq patchMemberLeaveReq) throws BaseException {
+        String pwd;
+
+        try{
+            pwd = memberLeaveRepository.getPassword(memberId);
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+
+        try {
+            pwd = new AES128(Secret.USER_INFO_PASSWORD_KEY).decrypt(pwd);
+        } catch (Exception e) {
+            throw new BaseException(PASSWORD_DECRYPTION_ERROR);
+        }
+
+        if(patchMemberLeaveReq.getPassword().equals(pwd)){
+            if(memberLeaveRepository.modifyMemberStatus(memberId) == 0){
+                throw new BaseException(FAILED_TO_MEMBERLEAVE);
+            }
+        }
+        else {
+            throw new BaseException(INVALID_PASSWORD);
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/service/MenteeProfileService.java
+++ b/src/main/java/MentosServer/mentos/service/MenteeProfileService.java
@@ -1,0 +1,40 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.dto.GetMenteeProfileRes;
+import MentosServer.mentos.model.dto.MenteeProfileDto;
+import MentosServer.mentos.repository.MenteeProfileRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+import static MentosServer.mentos.config.BaseResponseStatus.INVALID_MENTEEPROFILE;
+
+@Service
+public class MenteeProfileService {
+    private final MenteeProfileRepository menteeProfileRepository;
+
+    @Autowired
+    public MenteeProfileService(MenteeProfileRepository menteeProfileRepository){
+        this.menteeProfileRepository = menteeProfileRepository;
+    }
+
+    //멘티 프로필 조회
+    @Transactional(readOnly = true)
+    public GetMenteeProfileRes getMenteeProfile(int memberId) throws BaseException {
+        if(menteeProfileRepository.checkMenteeProfile(memberId) == 0){
+            throw new BaseException(INVALID_MENTEEPROFILE);
+        }
+        try{
+            MenteeProfileDto profileDto = menteeProfileRepository.getBasicInfoByMentee(memberId);
+            String schoolName = menteeProfileRepository.getSchoolName(profileDto.getSchoolId());
+            int numOfMentoring = menteeProfileRepository.getNumOfMentoringByMentee(memberId);
+
+
+            GetMenteeProfileRes getMenteeProfileRes = new GetMenteeProfileRes(profileDto, schoolName, numOfMentoring);
+            return getMenteeProfileRes;
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/service/MentorProfileService.java
+++ b/src/main/java/MentosServer/mentos/service/MentorProfileService.java
@@ -1,0 +1,51 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.domain.Post;
+import MentosServer.mentos.model.domain.Review;
+import MentosServer.mentos.model.dto.GetMentorProfileRes;
+import MentosServer.mentos.model.dto.MentorProfileDto;
+import MentosServer.mentos.model.dto.MentosCountDto;
+import MentosServer.mentos.model.dto.PostWithImageDto;
+import MentosServer.mentos.repository.MentorProfileRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+import static MentosServer.mentos.config.BaseResponseStatus.INVALID_MENTORPROFILE;
+
+@Service
+public class MentorProfileService {
+    private final MentorProfileRepository mentorProfileRepository;
+
+    @Autowired
+    public MentorProfileService(MentorProfileRepository mentorProfileRepository){
+        this.mentorProfileRepository = mentorProfileRepository;
+    }
+
+    //멘토 프로필 조회
+    @Transactional(readOnly = true)
+    public GetMentorProfileRes getMentorProfile(int memberId) throws BaseException{
+        if(mentorProfileRepository.checkMentorProfile(memberId) == 0){
+            throw new BaseException(INVALID_MENTORPROFILE);
+        }
+
+        try{
+            MentorProfileDto mentorProfileDto = mentorProfileRepository.getBasicInfoByMentor(memberId);
+            String schoolName = mentorProfileRepository.getSchoolName(mentorProfileDto.getSchoolId());
+            int numOfMentoring = mentorProfileRepository.getNumOfMentoringByMentor(memberId);
+            List<PostWithImageDto> posts = mentorProfileRepository.getPostsByMemberId(memberId);
+            List<Review> reviews = mentorProfileRepository.getReviewsOnMentor(memberId);
+            List<MentosCountDto> mentosCount = mentorProfileRepository.getMentosCount(memberId);
+
+            GetMentorProfileRes getMentorProfileRes = new GetMentorProfileRes(mentorProfileDto, schoolName, numOfMentoring, posts, reviews, mentosCount);
+            return getMentorProfileRes;
+
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+}

--- a/src/main/java/MentosServer/mentos/service/MyPageService.java
+++ b/src/main/java/MentosServer/mentos/service/MyPageService.java
@@ -1,0 +1,62 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.domain.Review;
+import MentosServer.mentos.model.dto.*;
+import MentosServer.mentos.repository.MenteeProfileRepository;
+import MentosServer.mentos.repository.MentorProfileRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+
+@Service
+public class MyPageService {
+    private final MentorProfileRepository mentorProfileRepository;
+    private final MenteeProfileRepository menteeProfileRepository;
+
+    @Autowired
+    public MyPageService(MentorProfileRepository mentorProfileRepository, MenteeProfileRepository menteeProfileRepository){
+        this.mentorProfileRepository = mentorProfileRepository;
+        this.menteeProfileRepository = menteeProfileRepository;
+    }
+
+    // 내 정보 화면 조회
+    @Transactional(readOnly = true)
+    public GetMyPageRes getMyPage(int memberId) throws BaseException {
+        try{
+            GetMentorProfileRes getMentorProfileRes = null;
+            GetMenteeProfileRes getMenteeProfileRes = null;
+
+            if(mentorProfileRepository.checkMentorProfile(memberId) == 1){ // 멘토 프로필 존재 여부 확인
+                MentorProfileDto mentorProfileDto = mentorProfileRepository.getBasicInfoByMentor(memberId);
+                String schoolName = mentorProfileRepository.getSchoolName(mentorProfileDto.getSchoolId());
+                int numOfMentoring = mentorProfileRepository.getNumOfMentoringByMentor(memberId);
+                List<PostWithImageDto> posts = mentorProfileRepository.getPostsByMemberId(memberId);
+                List<Review> reviews = mentorProfileRepository.getReviewsOnMentor(memberId);
+                List<MentosCountDto> mentosCount = mentorProfileRepository.getMentosCount(memberId);
+
+                getMentorProfileRes = new GetMentorProfileRes(mentorProfileDto, schoolName, numOfMentoring, posts, reviews, mentosCount);
+            }
+
+            if(menteeProfileRepository.checkMenteeProfile(memberId) == 1){ // 멘티 프로필 존재 여부 확인
+                MenteeProfileDto profileDto = menteeProfileRepository.getBasicInfoByMentee(memberId);
+                String schoolName = menteeProfileRepository.getSchoolName(profileDto.getSchoolId());
+                int numOfMentoring = menteeProfileRepository.getNumOfMentoringByMentee(memberId);
+
+
+                getMenteeProfileRes = new GetMenteeProfileRes(profileDto, schoolName, numOfMentoring);
+            }
+
+            GetMyPageRes getMyPageRes = new GetMyPageRes(getMentorProfileRes, getMenteeProfileRes);
+            return getMyPageRes;
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+
+}


### PR DESCRIPTION
## 프로필 조회 APIs & 회원 탈퇴 API
### API List
- 멘토 프로필 조회 API
- 멘티 프로필 조회 API
- 내 정보 조회 API
- 회원 탈퇴 API

### 멘토 프로필 조회 API
- 멘토 프로필 존재 여부 확인
### 멘티 프로필 조회 API
- 멘티 프로필 존재 여부 확인
### 내 정보 조회 API
- 멘토 프로필, 멘티 프로필 각각 존재 여부 확인 => 존재하는 경우 정보 가져옴, 존재하지 않으면 null
### 회원탈퇴 API
- jwt로부터 얻은 memberId로 비밀번호 가져옴
- 비밀번호 복호화 후, 입력한 비밀번호와 비교 => 같으면 memberStatus  = 'INACTIVE'로 변경 