### PR TITLE
FCM 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 /src/main/resources/application-aws.yml
 /src/main/resources/application-credentials.yml
 /src/main/java/MentosServer/mentos/config/secret/Secret.java
+/src/main/resources/firebase/firebase_service_key.json

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 	// spring cloud starter aws
 	implementation('org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE')
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+	// https://mvnrepository.com/artifact/com.google.firebase/firebase-admin
+	implementation group: 'com.google.firebase', name: 'firebase-admin', version: '6.8.1'
+// https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp
+	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.1'
+
 
 	//jwt
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.0'

--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -115,6 +115,8 @@ public enum BaseResponseStatus {
 
     EMPTY_MENTO_PROFILE(false,3410,"멘토 프로필이 존재하지 않습니다."),
     EMPTY_MENTEE_PROFILE(false,3411,"멘티 프로필이 존재하지 않습니다."),
+    EMPTY_MEMBER_DEVICE_TOKEN(false,3412,"디바이스 토큰이 존재하지 않습니다."),
+    FCM_SEND_ERROR(false,3413,"FCM 전송에 실패하였습니다"),
     /**
      * ROZY
      * 301 -  400 : Response 오류

--- a/src/main/java/MentosServer/mentos/controller/FcmTokenController.java
+++ b/src/main/java/MentosServer/mentos/controller/FcmTokenController.java
@@ -1,0 +1,61 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.DeviceTokenDto;
+import MentosServer.mentos.service.FcmTokenService;
+import MentosServer.mentos.service.FcmTokenServiceImpl;
+import MentosServer.mentos.utils.JwtService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static MentosServer.mentos.config.BaseResponseStatus.SUCCESS;
+
+@Slf4j
+@RestController
+public class FcmTokenController {
+    private final FcmTokenService fcmTokenService;
+    private final JwtService jwtService;
+
+    @Autowired
+    public FcmTokenController(FcmTokenServiceImpl fcmTokenService, JwtService jwtService) {
+        this.fcmTokenService = fcmTokenService;
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/device")
+    public BaseResponse updateDeviceToken(@RequestBody DeviceTokenDto deviceTokenDto) throws BaseException {
+        int memberIdByJwt = jwtService.getMemberId();
+        try {
+            //디바이스 등록
+            if (deviceTokenDto.getNewToken().equals(deviceTokenDto.getCurrToken())) {
+                log.info("등록");
+                fcmTokenService.insertNewUserDeviceToken(memberIdByJwt, deviceTokenDto.getCurrToken());
+            } else {
+                log.info("변경");
+                fcmTokenService.updateUserDeviceToken(memberIdByJwt, deviceTokenDto.getCurrToken(), deviceTokenDto.getNewToken());
+            }
+            return new BaseResponse<>(SUCCESS);
+        } catch (BaseException exception) {
+            return new BaseResponse<>(exception.getStatus());
+        }
+    }
+
+    //로그아웃 시에 삭제
+    @DeleteMapping("/device")
+    public BaseResponse deleteDeviceToken(@RequestBody DeviceTokenDto deviceTokenDto) throws BaseException {
+        int memberIdByJwt = jwtService.getMemberId();
+        try{
+            fcmTokenService.deleteUserDeviceToken(memberIdByJwt, deviceTokenDto.getCurrToken());
+            return new BaseResponse<>(SUCCESS);
+        }catch (BaseException exception) {
+            return new BaseResponse<>(exception.getStatus());
+        }
+    }
+
+
+}

--- a/src/main/java/MentosServer/mentos/model/dto/DeviceTokenDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/DeviceTokenDto.java
@@ -1,0 +1,22 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DeviceTokenDto {
+    private String currToken;
+    private String newToken;
+
+    //디바이스 생성 및 삭제
+    public DeviceTokenDto(String currToken) {
+        this.currToken = currToken;
+    }
+
+    //디바이스 변경
+    public DeviceTokenDto(String currToken, String newToken) {
+        this.currToken = currToken;
+        this.newToken = newToken;
+    }
+}

--- a/src/main/java/MentosServer/mentos/repository/FcmTokenRespository.java
+++ b/src/main/java/MentosServer/mentos/repository/FcmTokenRespository.java
@@ -1,0 +1,49 @@
+package MentosServer.mentos.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class FcmTokenRespository {
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public int insertNewUserDeviceToken(int memberId, String fcmToken) {
+        String query = "insert into userdevice (memberId,deviceToken) values (?,?)";
+        Object[] params = new Object[]{memberId, fcmToken};
+        return jdbcTemplate.update(query,params);
+    }
+
+    public List<String> selectUserDeviceTokenByIdx(int userIdx) {
+        List<String> tokenList = new ArrayList<>();
+        String query ="select userdevice from userdevice where memberId=? and deleteFlag=0";
+        jdbcTemplate.query(query,(rs,rowNum)->tokenList.add(rs.getString("deviceToken")),userIdx);
+        return tokenList;
+    }
+
+    public int deleteUserDeviceToken(int memberId, String fcmToken) {
+        String query = "update userdevice set deleteFlag=1 where memberId=? and deviceToken=?"; //하나 삭제 처리
+        Object[] params = new Object[]{memberId, fcmToken};
+        return jdbcTemplate.update(query,params);
+    }
+
+    public int updateUserDeviceToken(int memberId, String oldFcmToken, String newFcmToken) {
+        String query="update userdevice set deviceToken =? where deviceToken=? and memberId=?";
+        Object[] params = new Object[]{newFcmToken,oldFcmToken,memberId};
+        return jdbcTemplate.update(query,params);
+    }
+
+    public int deleteUserAllDeviceToken(int memberId) {
+        String query = "update userdevice set deleteFlag=1 where memberId=?";
+        return jdbcTemplate.update(query,memberId);
+    }
+}

--- a/src/main/java/MentosServer/mentos/repository/ReportRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/ReportRepository.java
@@ -53,4 +53,9 @@ public class ReportRepository {
 				),
 				mentoringId);
 	}
+
+	public int getMentoringMentee(int mentoringId) {
+		String query = "select mentoringMentiId from mentoring where mentoringId=?";
+		return this.jdbcTemplate.queryForObject(query,int.class,mentoringId);
+	}
 }

--- a/src/main/java/MentosServer/mentos/service/FcmTokenService.java
+++ b/src/main/java/MentosServer/mentos/service/FcmTokenService.java
@@ -1,0 +1,14 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+
+import java.util.List;
+
+public interface FcmTokenService{
+
+    int insertNewUserDeviceToken(int memberId, String fcmToken) throws BaseException;
+    List<String> selectUserDeviceTokenByIdx(int memberId) throws BaseException;
+    int deleteUserDeviceToken(int memberId, String fcmToken)throws BaseException;
+    int updateUserDeviceToken(int memberId, String oldFcmToken, String newFcmToken)throws BaseException;
+    int deleteUserAllDeviceToken(int memberId) throws BaseException;
+}

--- a/src/main/java/MentosServer/mentos/service/FcmTokenServiceImpl.java
+++ b/src/main/java/MentosServer/mentos/service/FcmTokenServiceImpl.java
@@ -1,0 +1,69 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.repository.FcmTokenRespository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+
+@Service
+public class FcmTokenServiceImpl implements FcmTokenService {
+    private final FcmTokenRespository fcmTokenRespository;
+
+    @Autowired
+    public FcmTokenServiceImpl(FcmTokenRespository fcmTokenRespository) {
+        this.fcmTokenRespository = fcmTokenRespository;
+    }
+
+    @Override
+    public int insertNewUserDeviceToken(int memberId, String fcmToken) throws BaseException {
+        try{
+            System.out.println("여기");
+            return fcmTokenRespository.insertNewUserDeviceToken(memberId,fcmToken);
+        }catch(Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    @Override
+    public List<String> selectUserDeviceTokenByIdx(int memberId)throws BaseException {
+        try{
+            return fcmTokenRespository.selectUserDeviceTokenByIdx(memberId);
+        }catch(Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    @Override
+    public int deleteUserDeviceToken(int memberId, String fcmToken)throws BaseException {
+        try{
+            return fcmTokenRespository.deleteUserDeviceToken(memberId,fcmToken);
+        }catch(Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    @Override
+    public int updateUserDeviceToken(int memberId, String oldFcmToken, String newFcmToken)throws BaseException {
+        try{
+            return fcmTokenRespository.updateUserDeviceToken(memberId,oldFcmToken,newFcmToken);
+        }catch(Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    @Override
+    public int deleteUserAllDeviceToken(int memberId) throws BaseException {
+        try{
+            return fcmTokenRespository.deleteUserAllDeviceToken(memberId);
+        }catch(Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+
+}

--- a/src/main/java/MentosServer/mentos/service/MemberLeaveService.java
+++ b/src/main/java/MentosServer/mentos/service/MemberLeaveService.java
@@ -14,11 +14,13 @@ import static MentosServer.mentos.config.BaseResponseStatus.*;
 @Service
 public class MemberLeaveService {
     private final MemberLeaveRepository memberLeaveRepository;
+    private final FcmTokenService fcmTokenService;
     private final JwtService jwtService;
 
     @Autowired
-    public MemberLeaveService(MemberLeaveRepository memberLeaveRepository, JwtService jwtService){
+    public MemberLeaveService(MemberLeaveRepository memberLeaveRepository, FcmTokenService fcmTokenService, JwtService jwtService){
         this.memberLeaveRepository = memberLeaveRepository;
+        this.fcmTokenService = fcmTokenService;
         this.jwtService = jwtService;
     }
 
@@ -39,6 +41,7 @@ public class MemberLeaveService {
         }
 
         if(patchMemberLeaveReq.getPassword().equals(pwd)){
+            fcmTokenService.deleteUserAllDeviceToken(memberId); //모든 디바이스 토큰 삭제
             if(memberLeaveRepository.modifyMemberStatus(memberId) == 0){
                 throw new BaseException(FAILED_TO_MEMBERLEAVE);
             }

--- a/src/main/java/MentosServer/mentos/service/MentoringService.java
+++ b/src/main/java/MentosServer/mentos/service/MentoringService.java
@@ -4,39 +4,62 @@ import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.model.domain.Mentoring;
 import MentosServer.mentos.model.dto.*;
 import MentosServer.mentos.repository.MentoringRepository;
+import MentosServer.mentos.utils.fcm.FirebaseCloudMessageService;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static MentosServer.mentos.config.BaseResponseStatus.*;
 
+@Slf4j
 @Service
 public class MentoringService {
-    final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final FcmTokenService fcmTokenService;
+    private final FirebaseCloudMessageService firebaseCloudMessageService;
     private final MentoringRepository mentoringRepository;
 
     @Autowired
-    public MentoringService(MentoringRepository mentoringRepository) {
+    public MentoringService(FcmTokenService fcmTokenService, FirebaseCloudMessageService firebaseCloudMessageService, MentoringRepository mentoringRepository) {
+        this.fcmTokenService = fcmTokenService;
+        this.firebaseCloudMessageService = firebaseCloudMessageService;
         this.mentoringRepository = mentoringRepository;
+    }
+    public void sendMessage(int memberId,String title, String body,int senderFlag) throws BaseException {
+        // 푸시 알림 보내기
+        List<String> memberToken = fcmTokenService.selectUserDeviceTokenByIdx(memberId);
+        if (memberToken.isEmpty()) {
+            log.error("Cannot found member device token");
+            throw new BaseException(EMPTY_MEMBER_DEVICE_TOKEN);
+        }
+        firebaseCloudMessageService.sendMessageTo(memberToken,title,body,senderFlag);
     }
 
     //멘토링 등록
     public PostMentoringRes createMentoring(PostMentoringReq postMentoringReq) throws BaseException {
-        if(mentoringRepository.checkMentoring(postMentoringReq) == 1){ // 멘토링 중복 신청 확인
+        if (mentoringRepository.checkMentoring(postMentoringReq) == 1) { // 멘토링 중복 신청 확인
             throw new BaseException(POST_MENTORING_DUPLICATED_MENTORING);
         }
-
-        try{
+        String title = "\u2028멘토링 요청이 도착했어요\uD83C\uDF89\u2028‘";
+        String body = "멘토링 현황’에서 수락 여부를 알려주세요-!";
+        PostMentoringRes postMentoringRes;
+        try {
             int mentoringId = mentoringRepository.createMentoring(postMentoringReq);
 
-            PostMentoringRes postMentoringRes = new PostMentoringRes(mentoringId, postMentoringReq.getMentoId(), postMentoringReq.getMentiId());
-
-            return postMentoringRes;
-        } catch (Exception e){
+            postMentoringRes = new PostMentoringRes(mentoringId, postMentoringReq.getMentoId(), postMentoringReq.getMentiId());
+        } catch (Exception e) {
             throw new BaseException(DATABASE_ERROR);
         }
+        //푸시 알림 보내기
+        sendMessage(postMentoringReq.getMentoId(), title, body, 1);//멘토에게
+        return postMentoringRes;
     }
 
     //멘토링 수락/거절
@@ -46,11 +69,12 @@ public class MentoringService {
             throw new BaseException(POST_INVALID_MENTORING);
         }
 
+        String title="";
+        String body="";
         try{
             PostAcceptMentoringRes postAcceptMentoringRes = new PostAcceptMentoringRes(mentoringId, mentoId, "");
-
+            Mentoring mentoring = mentoringRepository.getMentoring(mentoringId);
             if(acceptance){
-                Mentoring mentoring = mentoringRepository.getMentoring(mentoringId);
                 try{ //기존 멘토링이 진행 중인 경우, 새로 수락한 멘토링을 기존 멘토링과 합하고 새로 수락한 멘토링 요청 삭제
                     int beforeMentoringId = mentoringRepository.checkProceedingMentoring(mentoring.getMentoringMentoId(), mentoring.getMentoringMentiId(), mentoring.getMajorCategoryId());
 
@@ -61,12 +85,20 @@ public class MentoringService {
                 }
 
                 postAcceptMentoringRes.setStatus("성공적으로 멘토링 요청을 수락했습니다.");
+                title="\u2028\uD83C\uDF89멘토가 멘토링을 수락했어요\uD83C\uDF89";
+                body="멘토링이 시작되었습니다-!\n" +
+                        "\n" +
+                        "오늘도 멘토-쓰를 통해\n" +
+                        "한 층 더 발전된 하루를 만들기 바랍니다!";
             }
             else {
                 mentoringRepository.deleteMentoring(mentoringId);
                 postAcceptMentoringRes.setStatus("성공적으로 멘토링 요청을 거절했습니다.");
+                title="멘토가 멘토링 요청을 수락하지 않았어요";
+                body="괜찮아요\uD83D\uDE42\u2028\n" +
+                        "멘토-쓰 찾기에서 나에게 맞는 멘토를 다시 찾아보아요\u2028.";
             }
-
+            sendMessage(mentoring.getMentoringMentiId(),title,body,2); //멘티에게
             return postAcceptMentoringRes;
         } catch (Exception e){
             throw new BaseException(DATABASE_ERROR);

--- a/src/main/java/MentosServer/mentos/service/ReportService.java
+++ b/src/main/java/MentosServer/mentos/service/ReportService.java
@@ -1,28 +1,34 @@
 package MentosServer.mentos.service;
 
 import MentosServer.mentos.config.BaseException;
-import MentosServer.mentos.model.dto.GetReportRes;
 import MentosServer.mentos.model.dto.PostReportReq;
 import MentosServer.mentos.model.dto.ReportList;
 import MentosServer.mentos.repository.ReportRepository;
+import MentosServer.mentos.utils.fcm.FirebaseCloudMessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static MentosServer.mentos.config.BaseResponseStatus.DATABASE_ERROR;
+import static MentosServer.mentos.config.BaseResponseStatus.*;
 
 @Service
 @Transactional
 public class ReportService {
-
+	private final FcmTokenService fcmTokenService;
+	private final FirebaseCloudMessageService firebaseCloudMessageService;
 	private final ReportRepository reportRepository;
 	
 	@Autowired
-	public ReportService(ReportRepository reportRepository) {
+	public ReportService(FcmTokenService fcmTokenService, FirebaseCloudMessageService firebaseCloudMessageService, ReportRepository reportRepository) {
+		this.fcmTokenService = fcmTokenService;
+		this.firebaseCloudMessageService = firebaseCloudMessageService;
 		this.reportRepository = reportRepository;
 	}
+
 	
 	public int postReport(PostReportReq req) throws BaseException {
 		try{
@@ -35,6 +41,10 @@ public class ReportService {
 			int finCnt = reportRepository.getFinCnt(mentoringId);
 			if(finFlag == finCnt) { // 마지막 멘토링이라면 종료로 바꾸기
 				reportRepository.stopMentoring(mentoringId);
+				//멘티Id가져오기
+				int menteeId = reportRepository.getMentoringMentee(mentoringId);
+				List<String> menteeToken = fcmTokenService.selectUserDeviceTokenByIdx(menteeId);//멘티의 디바이스 토큰 정보 가져오기
+				firebaseCloudMessageService.sendMessageTo(menteeToken,"멘토링이 종료되었습니다-!","⭐️멘토링 별점 및 후기 남기기 잊지마세요✏️",2);//멘티에게 전송
 				return 2;
 			}
 			return 1;

--- a/src/main/java/MentosServer/mentos/utils/fcm/FcmMessage.java
+++ b/src/main/java/MentosServer/mentos/utils/fcm/FcmMessage.java
@@ -1,0 +1,30 @@
+package MentosServer.mentos.utils.fcm;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class FcmMessage {
+    private boolean validateOnly;
+    private Message message;
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Message {
+        private String to;
+        private Data data;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Data {
+        private String title;
+        private String body;
+        private int receiverFlag;
+    }
+}

--- a/src/main/java/MentosServer/mentos/utils/fcm/FirebaseCloudMessageService.java
+++ b/src/main/java/MentosServer/mentos/utils/fcm/FirebaseCloudMessageService.java
@@ -1,0 +1,83 @@
+package MentosServer.mentos.utils.fcm;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponseStatus;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+import org.apache.http.HttpHeaders;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static MentosServer.mentos.config.BaseResponseStatus.FCM_SEND_ERROR;
+
+@Component
+@RequiredArgsConstructor
+public class FirebaseCloudMessageService {
+
+    private final String API_URL = "https://fcm.googleapis.com/v1/projects/mentos-4adeb/messages:send";
+    private final ObjectMapper objectMapper;
+
+    public void sendMessageTo(List<String> targetToken, String title, String body, int flag) throws BaseException {
+        AtomicBoolean fcmPushSuccess = new AtomicBoolean(true);
+        targetToken.forEach(i-> {
+            try {
+            String message = makeMessage(i, title, body, flag);
+
+            OkHttpClient client = new OkHttpClient();
+            RequestBody requestBody = RequestBody.create(message,
+                    MediaType.get("application/json; charset=utf-8"));
+            Request request = null;
+                request = new Request.Builder()
+                        .url(API_URL)
+                        .post(requestBody)
+                        .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+                        .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+                        .build();
+
+
+                Response response = client.newCall(request).execute();
+
+                System.out.println(response.body().string());
+            }catch (IOException e) {
+                fcmPushSuccess.set(false);
+            }
+        });
+        if(!fcmPushSuccess.get()){
+            throw new BaseException(FCM_SEND_ERROR);
+        }
+    }
+    private String makeMessage(String targetToken, String title, String body,int flag) throws JsonParseException, JsonProcessingException {
+        FcmMessage fcmMessage = FcmMessage.builder()
+                .message(FcmMessage.Message.builder()
+                        .to(targetToken)
+                        .data(FcmMessage.Data.builder()
+                                .title(title)
+                                .body(body)
+                                .receiverFlag(flag)
+                                .build()
+                        ).build()).validateOnly(false).build();
+
+        return objectMapper.writeValueAsString(fcmMessage);
+    }
+
+    private String getAccessToken() throws IOException {
+        String firebaseConfigPath = "firebase/firebase_service_key.json";
+
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+
+        googleCredentials.refreshIfExpired();
+        return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+}
+


### PR DESCRIPTION
## 설정 관련
### [build.gradle 의존성 추가]
- firebase admin
- okhttp
### [BaseResponseStatus]
- status 추가
## 기능 설명
### [fcm 메세지 전송]
- 현재는 회의록에 적었던 3가지 경우만 푸시알람을 보내도록 했습니다. 
- fcmTokenService를 이용해서 사용자가 로그인한 모든 기기 토큰 정보를 가져옵니다.
- 그 후 토큰마다 [title,body,receiverFlag]내용을 담은 메시지를 전송합니다.
- receiverFlag는 수신자의 멘토/멘티 상태

**메시지 전송은 따로 테스트를 해볼 수 없어서 main에 올린 후 수정을 진행하려고 합니다.**

### [디바이스 토큰 관리]
- 안드로이드에서 onNewToken()이 감지될 때 마다 생성/수정 api를 호출
- 로그아웃 시 디바이스 토큰 정보를 삭제하기 위한 삭제 api 호출
- 회원탈퇴 시 해당 사용자의 모든 디바이스 정보를 삭제하도록 구현했습니다.(이때는 api 호출 따로 없음)