### PR TITLE
신고 API 구현

### DIFF
--- a/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
+++ b/src/main/java/MentosServer/mentos/config/BaseResponseStatus.java
@@ -97,8 +97,9 @@ public enum BaseResponseStatus {
     DUPLICATED_EMAIL(false, 3013, "중복된 이메일입니다."),
     FAILED_TO_LOGIN(false,3014,"없는 아이디거나 비밀번호가 틀렸습니다."),
     
-    // [POST] /items
-    DUPLICATED_ITEM_NAME(false, 3015, "중복된 아이템 이름입니다."),
+    // [POST] /complain
+    EMAIL_MAKE_ERROR(false, 3015, "메일을 생성하는데 실패하였습니다."),
+    
     DUPLICATED_NICKNAME(false, 3401, "중복된 닉네임입니다."),
     VALID_USER_NICKNAME(true,3402,"사용가능한 닉네임입니다."),
     //[DELETE]/board

--- a/src/main/java/MentosServer/mentos/controller/ComplainController.java
+++ b/src/main/java/MentosServer/mentos/controller/ComplainController.java
@@ -1,0 +1,45 @@
+package MentosServer.mentos.controller;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.config.BaseResponse;
+import MentosServer.mentos.model.dto.GetComplainReq;
+import MentosServer.mentos.model.dto.MailDto;
+import MentosServer.mentos.service.ComplainService;
+import MentosServer.mentos.service.MailService;
+import MentosServer.mentos.utils.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ComplainController {
+
+	private ComplainService complainService;
+	private MailService mailService;
+	private JwtService jwtService;
+	
+	private String email = "teammentos0214@gmail.com";
+	
+	@Autowired
+	public ComplainController(ComplainService complainService, MailService mailService, JwtService jwtService) {
+		this.complainService = complainService;
+		this.mailService = mailService;
+		this.jwtService = jwtService;
+	}
+	
+	@PostMapping("/complain")
+	public BaseResponse<String> getCategory(@RequestBody GetComplainReq req){
+		try {
+			// jwt에서 memberId 뽑아내기
+			int memberId = jwtService.getMemberId();
+			// 메일 내용 생성
+			String text = complainService.makeMailText(memberId, req);
+			MailDto mailDto = new MailDto(email, "신고", text);
+			mailService.mailSend(mailDto);
+			return new BaseResponse<String>("메일 전송에 성공하였습니다.");
+		} catch (BaseException exception) {
+			return new BaseResponse<>((exception.getStatus()));
+		}
+	}
+}

--- a/src/main/java/MentosServer/mentos/model/dto/GetComplainReq.java
+++ b/src/main/java/MentosServer/mentos/model/dto/GetComplainReq.java
@@ -1,0 +1,15 @@
+package MentosServer.mentos.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GetComplainReq {
+	
+	int flag;
+	
+	int number;
+	
+	String text;
+}

--- a/src/main/java/MentosServer/mentos/service/ComplainService.java
+++ b/src/main/java/MentosServer/mentos/service/ComplainService.java
@@ -1,0 +1,29 @@
+package MentosServer.mentos.service;
+
+import MentosServer.mentos.config.BaseException;
+import MentosServer.mentos.model.dto.GetComplainReq;
+import org.springframework.stereotype.Service;
+
+import static MentosServer.mentos.config.BaseResponseStatus.EMAIL_MAKE_ERROR;
+
+@Service
+public class ComplainService {
+	
+	public String makeMailText(int memberId, GetComplainReq req) throws BaseException{
+		try{
+			String str = "";
+			int flag = req.getFlag();
+			if(flag == 1) str = "멘토쓰 글";
+			else if(flag == 2) str = "프로필";
+			else str = "채팅";
+			
+			return "멤버로부터 신고가 들어왔습니다!\n" +
+					"신고 한 멤버 아이디 = " + memberId + "\n" +
+					"신고 분류 = " + str + "\n" +
+					"신고 당한 멤버 아이디 또는 멘토쓰 글 번호 = " + req.getNumber() + "\n" +
+					"신고 내용 = " + req.getText() + "\n";
+		} catch (Exception exception) {
+			throw new BaseException(EMAIL_MAKE_ERROR);
+		}
+	}
+}

--- a/src/main/java/MentosServer/mentos/service/MailService.java
+++ b/src/main/java/MentosServer/mentos/service/MailService.java
@@ -1,10 +1,12 @@
 package MentosServer.mentos.service;
 
+import MentosServer.mentos.config.BaseException;
 import MentosServer.mentos.model.dto.MailDto;
 import lombok.AllArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import static MentosServer.mentos.config.BaseResponseStatus.MAIL_SEND_ERROR;
 
 @Service
 @AllArgsConstructor
@@ -13,12 +15,16 @@ public class MailService {
 	private JavaMailSender mailSender;
 	private static final String FROM_ADDRESS = "MENTOS@gmail.com";
 
-	public void mailSend(MailDto mailDto){
-		SimpleMailMessage message = new SimpleMailMessage();
-		message.setTo(mailDto.getAddress());
-		message.setFrom(MailService.FROM_ADDRESS);
-		message.setSubject(mailDto.getTitle());
-		message.setText(mailDto.getMessage());
-		mailSender.send(message);
+	public void mailSend(MailDto mailDto) throws BaseException{
+		try{
+			SimpleMailMessage message = new SimpleMailMessage();
+			message.setTo(mailDto.getAddress());
+			message.setFrom(MailService.FROM_ADDRESS);
+			message.setSubject(mailDto.getTitle());
+			message.setText(mailDto.getMessage());
+			mailSender.send(message);
+		} catch (Exception exception) {
+			throw new BaseException(MAIL_SEND_ERROR);
+		}
 	}
 }


### PR DESCRIPTION
신고 기능을 구현하였습니다.

## Flag 관련

1 = 멘토쓰 찾기 → 멘토 글 신고

2 = 회원 신고 → 프로필

3 = 회원 신고 → 채팅

## 신고 메일 내용

1. 신고 한 멤버 아이디
2. 신고 분류 = 멘토쓰 글, 프로필, 채팅
3. 신고 당한 멤버 아이디 또는 멘토쓰 글 번호
4. 신고 내용

더 자세한 내용은 API 명세서에 작성해놓았습니다.