### PR TITLE
멘토 글 찾기 API 반환값 수정

### DIFF
--- a/src/main/java/MentosServer/mentos/model/dto/PostDto.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostDto.java
@@ -2,7 +2,6 @@ package MentosServer.mentos.model.dto;
 
 import lombok.Data;
 
-
 @Data
 public class PostDto {
 	
@@ -16,18 +15,21 @@ public class PostDto {
 	
 	private String mentoNickName;
 	
+	private String mentoImage;
+	
 	private String postTitle;
 	
 	private String postContents;
 	
 	private String imageUrl;
 	
-	public PostDto(int postId, int majorCategoryId, int mentoId, String memberMajor, String mentoNickName, String postTitle, String postContents) {
+	public PostDto(int postId, int majorCategoryId, int mentoId, String memberMajor, String mentoNickName, String mentoImage, String postTitle, String postContents) {
 		this.postId = postId;
 		this.majorCategoryId = majorCategoryId;
 		this.mentoId = mentoId;
 		this.memberMajor = memberMajor;
 		this.mentoNickName = mentoNickName;
+		this.mentoImage = mentoImage;
 		this.postTitle = postTitle;
 		this.postContents = postContents;
 	}

--- a/src/main/java/MentosServer/mentos/model/dto/PostWithProfile.java
+++ b/src/main/java/MentosServer/mentos/model/dto/PostWithProfile.java
@@ -19,6 +19,8 @@ public class PostWithProfile implements Comparable<PostWithProfile>{
 	
 	private String memberMajor;
 	
+	private String mentoImage;
+	
 	private String postTitle;
 	
 	private String postContents;

--- a/src/main/java/MentosServer/mentos/repository/MentorSearchRepository.java
+++ b/src/main/java/MentosServer/mentos/repository/MentorSearchRepository.java
@@ -47,7 +47,7 @@ public class MentorSearchRepository {
 	public List<PostWithProfile> getPosts(GetMentorSearchReq req, String schoolId){
 		String arrayToString = String.join(",", req.getMajorFlag());
 		String searchQuery =
-				"select postId, majorCategoryId, memberId, memberNickName, memberMajor, postTitle, postContents, postCreateAt, postUpdateAt " +
+				"select postId, majorCategoryId, memberId, memberNickName, memberMajor, mentoImage, postTitle, postContents, postCreateAt, postUpdateAt " +
 				"from " +
 					"(" +
 					"select * " +
@@ -64,6 +64,7 @@ public class MentorSearchRepository {
 						rs.getInt("memberId"),
 						rs.getString("memberNickName"),
 						rs.getString("memberMajor"),
+						rs.getString("mentoImage"),
 						rs.getString("postTitle"),
 						rs.getString("postContents"),
 						rs.getTimestamp("postCreateAt"),

--- a/src/main/java/MentosServer/mentos/service/MentorSearchService.java
+++ b/src/main/java/MentosServer/mentos/service/MentorSearchService.java
@@ -79,7 +79,7 @@ public class MentorSearchService {
 		Collections.sort(arr);
 		for(PostWithProfile p : arr){
 			ret.add(new PostDto(p.getPostId(), p.getMajorCategoryId(), p.getMemberId(), p.getMemberMajor(),
-					p.getMemberNickName(), p.getPostTitle(), p.getPostContents()));
+					p.getMemberNickName(), p.getMentoImage(), p.getPostTitle(), p.getPostContents()));
 		}
 		return ret;
 	}


### PR DESCRIPTION
멘토가 작성한 글 반환 시 멘토 프로필 image도 같이 반환하게 변경하였습니다.

이유는 멘토스 찾기 -> 글 -> 멘토와 대화하기 부분으로 연결되는 과정에서, 채팅방의 프로필 이미지를 띄우려면 멘토스 찾기에서 멘토 프로필 이미지 url도 같이 보내야 된다고 합니다.